### PR TITLE
⚡ Bolt: Fix N+1 Google Calendar API queries in manual batch import

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [Batch Calendar Fetch]
+**Learning:** Google Apps Script calendar operations (like `getEvents`) are notoriously slow. In loops, they easily become bottlenecks.
+**Action:** Always batch fetch calendar events upfront using `getEvents(startDate, endDate)` when iterating over multiple entries, and use a hashmap (like a `Set`) locally in V8 for fast O(1) existence checks.

--- a/main.js
+++ b/main.js
@@ -69,23 +69,24 @@ function sendErrorEmail(message) {
 // ==========================================
 // アクティビティをカレンダーに登録する共通処理
 // ==========================================
-function processActivityToCalendar(activity, calendar, distanceActivities = DISTANCE_ACTIVITIES) {
+function processActivityToCalendar(activity, calendar, distanceActivities = DISTANCE_ACTIVITIES, skipDuplicateCheck = false) {
   // 時間の計算（Stravaは世界標準時なので、日本時間に合わせる必要があります）
   const startTime = new Date(activity.start_date);
   const endTime = new Date(startTime.getTime() + (activity.elapsed_time * 1000));
 
   // 既に登録済みのアクティビティかどうかを判定する (in-lined)
-  // ⚡ Bolt: manual_import で事前フィルタリングされるようになりましたが、
-  // 日次バッチ (main) のために念のためここでもチェックを残します。
-  const existingEvents = calendar.getEvents(startTime, endTime);
-  const isDuplicate = existingEvents.some(event => {
-    const desc = event.getDescription();
-    return desc && desc.includes(`strava.com/activities/${activity.id}`);
-  });
+  // ⚡ Bolt: skipDuplicateCheck フラグで事前チェックをバイパスできるように変更
+  if (!skipDuplicateCheck) {
+    const existingEvents = calendar.getEvents(startTime, endTime);
+    const isDuplicate = existingEvents.some(event => {
+      const desc = event.getDescription();
+      return desc && desc.includes(`strava.com/activities/${activity.id}`);
+    });
 
-  if (isDuplicate) {
-    Logger.log(`スキップ: 既に登録済みのアクティビティです: ${activity.id}`);
-    return 'skipped';
+    if (isDuplicate) {
+      Logger.log(`スキップ: 既に登録済みのアクティビティです: ${activity.id}`);
+      return 'skipped';
+    }
   }
 
   // ーーー ここから下は「新規」の時しか実行されない ーーー

--- a/main.js
+++ b/main.js
@@ -75,6 +75,8 @@ function processActivityToCalendar(activity, calendar, distanceActivities = DIST
   const endTime = new Date(startTime.getTime() + (activity.elapsed_time * 1000));
 
   // 既に登録済みのアクティビティかどうかを判定する (in-lined)
+  // ⚡ Bolt: manual_import で事前フィルタリングされるようになりましたが、
+  // 日次バッチ (main) のために念のためここでもチェックを残します。
   const existingEvents = calendar.getEvents(startTime, endTime);
   const isDuplicate = existingEvents.some(event => {
     const desc = event.getDescription();

--- a/manual_import.js
+++ b/manual_import.js
@@ -38,7 +38,32 @@ function importPastActivities(startDate, endDate, perPage = 200) {
     let successCount = 0;
     let skipCount = 0;
 
+    // ⚡ Bolt Optimization: Batch load existing events to avoid N+1 queries
+    // Fetch all events for the entire import period in one Calendar API call
+    const existingEvents = calendar.getEvents(startDate, endDate);
+
+    // Create a Set of existing Strava activity IDs for O(1) lookup
+    const existingActivityIds = new Set();
+    existingEvents.forEach(event => {
+        const desc = event.getDescription();
+        if (desc) {
+            const match = desc.match(/strava\.com\/activities\/(\d+)/);
+            if (match && match[1]) {
+                existingActivityIds.add(match[1]);
+            }
+        }
+    });
+
+    Logger.log(`[Import] 既にカレンダーにあるイベントを ${existingActivityIds.size} 件検出しました。`);
+
     activities.forEach(activity => {
+        const activityIdStr = String(activity.id);
+        if (existingActivityIds.has(activityIdStr)) {
+            Logger.log(`スキップ: 既に登録済みのアクティビティです: ${activity.id}`);
+            skipCount++;
+            return;
+        }
+
         const result = processActivityToCalendar(activity, calendar);
         if (result === 'skipped') skipCount++;
         if (result === 'success') successCount++;

--- a/manual_import.js
+++ b/manual_import.js
@@ -43,6 +43,8 @@ function importPastActivities(startDate, endDate, perPage = 200) {
     const existingEvents = calendar.getEvents(startDate, endDate);
 
     // Create a Set of existing Strava activity IDs for O(1) lookup
+    // Note: event.getDescription() does trigger a read in CalendarApp, but this is still
+    // vastly faster than getEvents() for every single activity in the list.
     const existingActivityIds = new Set();
     existingEvents.forEach(event => {
         const desc = event.getDescription();
@@ -64,7 +66,8 @@ function importPastActivities(startDate, endDate, perPage = 200) {
             return;
         }
 
-        const result = processActivityToCalendar(activity, calendar);
+        // ⚡ Bolt: Pass skipDuplicateCheck=true because we already filtered duplicates above
+        const result = processActivityToCalendar(activity, calendar, undefined, true);
         if (result === 'skipped') skipCount++;
         if (result === 'success') successCount++;
     });

--- a/tests/manual_import.spec.js
+++ b/tests/manual_import.spec.js
@@ -66,24 +66,27 @@ describe('manual_import', () => {
             { id: 102, name: 'Activity 2' },
             { id: 103, name: 'Activity 3' }
         ];
-        const mockCalendar = { getName: () => 'Test Calendar' };
+        const mockCalendar = {
+            getName: () => 'Test Calendar',
+            getEvents: vi.fn(() => [
+                { getDescription: () => 'strava.com/activities/102' }
+            ])
+        };
 
         global.getStravaActivities.mockReturnValue(mockActivities);
         global.getTargetCalendar.mockReturnValue(mockCalendar);
 
-        // Return 'success' for two and 'skipped' for one
+        // Mock the results for the two activities that are actually processed
         global.processActivityToCalendar
             .mockReturnValueOnce('success')
-            .mockReturnValueOnce('skipped')
-            .mockReturnValueOnce('success');
+            .mockReturnValueOnce('success'); // The second call is now for activity 3, as activity 2 is skipped beforehand
 
         const result = importPastActivities(startDate, endDate);
 
         expect(result).toBe('✅ 完了! 新規登録: 2件 / スキップ: 1件');
-        expect(global.processActivityToCalendar).toHaveBeenCalledTimes(3);
+        expect(global.processActivityToCalendar).toHaveBeenCalledTimes(2);
         expect(global.processActivityToCalendar).toHaveBeenNthCalledWith(1, mockActivities[0], mockCalendar);
-        expect(global.processActivityToCalendar).toHaveBeenNthCalledWith(2, mockActivities[1], mockCalendar);
-        expect(global.processActivityToCalendar).toHaveBeenNthCalledWith(3, mockActivities[2], mockCalendar);
+        expect(global.processActivityToCalendar).toHaveBeenNthCalledWith(2, mockActivities[2], mockCalendar);
         expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('完了!'));
     });
 });

--- a/tests/manual_import.spec.js
+++ b/tests/manual_import.spec.js
@@ -85,8 +85,8 @@ describe('manual_import', () => {
 
         expect(result).toBe('✅ 完了! 新規登録: 2件 / スキップ: 1件');
         expect(global.processActivityToCalendar).toHaveBeenCalledTimes(2);
-        expect(global.processActivityToCalendar).toHaveBeenNthCalledWith(1, mockActivities[0], mockCalendar);
-        expect(global.processActivityToCalendar).toHaveBeenNthCalledWith(2, mockActivities[2], mockCalendar);
+        expect(global.processActivityToCalendar).toHaveBeenNthCalledWith(1, mockActivities[0], mockCalendar, undefined, true);
+        expect(global.processActivityToCalendar).toHaveBeenNthCalledWith(2, mockActivities[2], mockCalendar, undefined, true);
         expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('完了!'));
     });
 });


### PR DESCRIPTION
💡 **What:** Modified `importPastActivities` in `manual_import.js` to batch load all existing calendar events for the selected date range upfront using `calendar.getEvents()`. The fetched events are parsed to extract Strava Activity IDs, which are then stored in a `Set` for O(1) existence checks.
🎯 **Why:** Previously, `calendar.getEvents` was called inside `processActivityToCalendar` for *every* fetched activity to check for duplicates. Calling Google Apps Script APIs inside a loop introduces an N+1 query problem, creating a massive bottleneck during bulk imports and risking script timeouts.
📊 **Impact:** Turns O(N) Calendar API reads into O(1) read during bulk imports. Massively reduces execution time when importing large amounts of previously synced historical data.
🔬 **Measurement:** Can be verified by running a manual import for a period of several months that has already been synced. The total execution time and API call quota usage will be significantly lower. Tests ensure counts correctly reflect `skip` and `success`.

---
*PR created automatically by Jules for task [7603887162349735870](https://jules.google.com/task/7603887162349735870) started by @kurousa*