### PR TITLE
🧹 [code health] Extract hardcoded sleep durations into constants

### DIFF
--- a/api.js
+++ b/api.js
@@ -4,6 +4,8 @@
 // ==========================================
 
 const API_BASE = "https://www.strava.com/api/v3";
+// Strava APIのレート制限（連続アクセス制限）対策の待機時間 (ms)
+const STRAVA_API_DELAY_MS = 200;
 
 /**
  * Stravaから指定期間のアクティビティを全件取得する（ページネーション対応）
@@ -68,7 +70,7 @@ function getStravaActivities(afterDate, beforeDate, perPage = 200) {
       page++;
 
       // Strava APIのレート制限（連続アクセス制限）対策
-      Utilities.sleep(200);
+      Utilities.sleep(STRAVA_API_DELAY_MS);
 
     } catch (e) {
       const errorMsg = 'Strava APIの呼び出しに失敗しました: ' + e.toString();

--- a/main.js
+++ b/main.js
@@ -5,6 +5,9 @@
 // ==========================================
 
 const CALENDAR_ID = PropertiesService.getScriptProperties().getProperty('CALENDAR_ID');
+// カレンダーAPIの連続作成制限を回避するための待機時間 (ms)
+const CALENDAR_API_DELAY_MS = 200;
+
 // 距離を表示するアクティビティのリスト
 const DISTANCE_ACTIVITIES = [
   'Run', 'Ride', 'Walk', 'Hike', 'Swim', 'AlpineSki', 'BackcountrySki', 'NordicSki', 'RollerSki',
@@ -117,8 +120,8 @@ function processActivityToCalendar(activity, calendar, distanceActivities = DIST
   }
 
   // カレンダーAPIの連続作成制限を回避しつつ、GASの実行時間制限(6分)に配慮
-  // 重複スキップ時は待機せず、カレンダーへの新規書き込みが行われた直後のみ短時間(200ms)待機する
-  Utilities.sleep(200);
+  // 重複スキップ時は待機せず、カレンダーへの新規書き込みが行われた直後のみ短時間待機する
+  Utilities.sleep(CALENDAR_API_DELAY_MS);
 
   Logger.log(`カレンダーに登録しました: ${title}`);
   return 'success';


### PR DESCRIPTION
This PR improves code maintainability and readability by extracting hardcoded sleep durations into well-named constants at the top of `main.js` and `api.js`.

🎯 **What:** The code health issue of "Hardcoded Sleep Duration" has been addressed.
💡 **Why:** Magic numbers like `200` are now replaced with `CALENDAR_API_DELAY_MS` and `STRAVA_API_DELAY_MS`, making it easier to adjust these values in the future and clarifying their purpose.
✅ **Verification:** Verified that the constants are correctly defined and used via `read_file`. Performed a syntax check using `node -c main.js api.js` which passed.
✨ **Result:** Improved maintainability and consistency across the codebase.

---
*PR created automatically by Jules for task [8096310670918793179](https://jules.google.com/task/8096310670918793179) started by @kurousa*