### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/kurousa/strava-calendar-app/security/code-scanning/2](https://github.com/kurousa/strava-calendar-app/security/code-scanning/2)

In general, the fix is to define an explicit `permissions` block for the workflow or for the specific job, restricting the `GITHUB_TOKEN` to the least privileges required. For a build-and-deploy-to-GAS job that does not modify GitHub resources, `contents: read` is typically sufficient.

For this workflow, the minimal change is to add a `permissions` section inside the `deploy` job (or at the root). To keep the change tightly scoped to the highlighted job, add:

```yaml
permissions:
  contents: read
```

under `jobs: deploy:` and at the same indentation as `runs-on`. No other steps rely on `GITHUB_TOKEN` for write operations, so this should not change existing functionality. No additional imports or external tools are required.

Concretely, in `.github/workflows/deploy.yml`, between line 18 (`deploy:`) and line 19 (`runs-on: ubuntu-latest`), insert the `permissions` block at two-space indentation under `deploy:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
