### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Unit Test Suite
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/kurousa/strava-calendar-app/security/code-scanning/1](https://github.com/kurousa/strava-calendar-app/security/code-scanning/1)

In general, fix this by adding an explicit `permissions` block that grants only the scopes required by the job. For a workflow that only needs to read repository contents (checkout) and does not create or modify any GitHub resources, `contents: read` is sufficient. Defining this at the workflow root applies to all jobs; defining it at the job level restricts that specific job.

For this specific workflow, the simplest and safest fix without changing existing functionality is to add a `permissions` block with `contents: read` at the top level, just under `name: Unit Test Suite` (before `on:`). This documents that the workflow only needs read access and ensures that even if org/repo defaults are broader (read‑write), this workflow’s token remains read-only. No additional imports or methods are needed, since this is purely a YAML configuration change.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between line 1 (`name: Unit Test Suite`) and line 3 (`on:`), respecting YAML indentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
