### PR TITLE
🧪 Refactor `getActivityStyle` tests and add immutability coverage

### DIFF
--- a/tests/DefaultFormatter.spec.js
+++ b/tests/DefaultFormatter.spec.js
@@ -40,44 +40,38 @@ describe('DefaultFormatter', () => {
     });
 
     describe('getActivityStyle', () => {
-        it('should return correct style for Walk', () => {
-            expect(getActivityStyle('Walk')).toEqual({ emoji: '🚶', color: 'GREEN' });
+        const styleTestCases = [
+            ['Walk', { emoji: '🚶', color: 'GREEN' }],
+            ['Run', { emoji: '🏃', color: 'BLUE' }],
+            ['VirtualRun', { emoji: '🏃', color: 'BLUE' }],
+            ['Ride', { emoji: '🚴', color: 'RED' }],
+            ['VirtualRide', { emoji: '🚴', color: 'RED' }],
+            ['Swim', { emoji: '🏊', color: 'CYAN' }],
+            ['Hike', { emoji: '🥾', color: 'PALE_GREEN' }],
+            ['Workout', { emoji: '🏋️', color: 'ORANGE' }],
+            ['WeightTraining', { emoji: '🏋️', color: 'ORANGE' }],
+            ['Unknown', { emoji: '🏅', color: 'GRAY' }] // Default case
+        ];
+
+        it.each(styleTestCases)('should return correct style for %s', (type, expectedStyle) => {
+            expect(getActivityStyle(type)).toEqual(expectedStyle);
         });
 
-        it('should return correct style for Run', () => {
-            expect(getActivityStyle('Run')).toEqual({ emoji: '🏃', color: 'BLUE' });
-        });
+        it('should return an immutable (frozen) object to prevent cache side-effects', () => {
+            const style = getActivityStyle('Run');
 
-        it('should return correct style for VirtualRun', () => {
-            expect(getActivityStyle('VirtualRun')).toEqual({ emoji: '🏃', color: 'BLUE' });
-        });
+            // Verify the object is frozen
+            expect(Object.isFrozen(style)).toBe(true);
 
-        it('should return correct style for Ride', () => {
-            expect(getActivityStyle('Ride')).toEqual({ emoji: '🚴', color: 'RED' });
-        });
+            // Attempting to mutate should fail in strict mode (which vitest uses)
+            // We use a try/catch or expect().toThrow to handle if strict mode applies
+            expect(() => {
+                'use strict';
+                style.emoji = '🚀';
+            }).toThrow(TypeError);
 
-        it('should return correct style for VirtualRide', () => {
-            expect(getActivityStyle('VirtualRide')).toEqual({ emoji: '🚴', color: 'RED' });
-        });
-
-        it('should return correct style for Swim', () => {
-            expect(getActivityStyle('Swim')).toEqual({ emoji: '🏊', color: 'CYAN' });
-        });
-
-        it('should return correct style for Hike', () => {
-            expect(getActivityStyle('Hike')).toEqual({ emoji: '🥾', color: 'PALE_GREEN' });
-        });
-
-        it('should return correct style for Workout', () => {
-            expect(getActivityStyle('Workout')).toEqual({ emoji: '🏋️', color: 'ORANGE' });
-        });
-
-        it('should return correct style for WeightTraining', () => {
-            expect(getActivityStyle('WeightTraining')).toEqual({ emoji: '🏋️', color: 'ORANGE' });
-        });
-
-        it('should return default style for unknown type', () => {
-            expect(getActivityStyle('Unknown')).toEqual({ emoji: '🏅', color: 'GRAY' });
+            // The original object should remain unchanged regardless
+            expect(style.emoji).toBe('🏃');
         });
     });
 });

--- a/tests/DefaultFormatter.spec.js
+++ b/tests/DefaultFormatter.spec.js
@@ -63,15 +63,11 @@ describe('DefaultFormatter', () => {
             // Verify the object is frozen
             expect(Object.isFrozen(style)).toBe(true);
 
-            // Attempting to mutate should fail in strict mode (which vitest uses)
-            // We use a try/catch or expect().toThrow to handle if strict mode applies
+            // Attempting to mutate a frozen object should throw a TypeError in strict mode.
             expect(() => {
                 'use strict';
                 style.emoji = '🚀';
             }).toThrow(TypeError);
-
-            // The original object should remain unchanged regardless
-            expect(style.emoji).toBe('🏃');
         });
     });
 });


### PR DESCRIPTION
🎯 **What:** 
The `getActivityStyle` function had tests, but they were verbose and did not adequately verify a crucial part of its contract: returning immutable objects to prevent cache side-effects. This testing gap has been addressed.

📊 **Coverage:** 
- Converted repetitive `getActivityStyle` test assertions into clean, table-driven tests (`it.each`).
- Added explicit test coverage checking `Object.isFrozen(style)` to guarantee the `ACTIVITY_STYLES_CACHE` outputs immutable objects as expected by the `deepFreeze` helper pattern.

✨ **Result:** 
- The test suite for `getActivityStyle` is now more maintainable and concise.
- Increased the reliability of the formatter cache by asserting that clients cannot unintentionally mutate emojis or colors.

---
*PR created automatically by Jules for task [15593597894804339554](https://jules.google.com/task/15593597894804339554) started by @kurousa*