### PR TITLE
🧪 test: add tests for makeDescription routing logic

### DIFF
--- a/tests/DefaultFormatter.spec.js
+++ b/tests/DefaultFormatter.spec.js
@@ -14,8 +14,6 @@ global.CalendarApp = {
 };
 
 import { makeDefaultDescription, getActivityStyle, makeDescription } from '../formatters/DefaultFormatter';
-import { makeRideDescription } from '../formatters/RideFormatter';
-import { makeRunDescription } from '../formatters/RunFormatter';
 
 describe('DefaultFormatter', () => {
     describe('makeDefaultDescription', () => {

--- a/tests/DefaultFormatter.spec.js
+++ b/tests/DefaultFormatter.spec.js
@@ -14,6 +14,8 @@ global.CalendarApp = {
 };
 
 import { makeDefaultDescription, getActivityStyle, makeDescription } from '../formatters/DefaultFormatter';
+import { makeRideDescription } from '../formatters/RideFormatter';
+import { makeRunDescription } from '../formatters/RunFormatter';
 
 describe('DefaultFormatter', () => {
     describe('makeDefaultDescription', () => {
@@ -86,13 +88,12 @@ describe('DefaultFormatter', () => {
             // makeDescription internally calls global makeRideDescription and makeRunDescription
             // because in GAS they are in the same global scope.
             // We mock them globally for tests to verify routing behavior.
-            global.makeRideDescription = vi.fn((activity) => `RIDE: ${activity.id}`);
-            global.makeRunDescription = vi.fn((activity) => `RUN: ${activity.id}`);
+            vi.stubGlobal('makeRideDescription', vi.fn((activity) => `RIDE: ${activity.id}`));
+            vi.stubGlobal('makeRunDescription', vi.fn((activity) => `RUN: ${activity.id}`));
         });
 
         afterEach(() => {
-            delete global.makeRideDescription;
-            delete global.makeRunDescription;
+            vi.unstubAllGlobals();
         });
 
         it('should delegate to makeRideDescription for Ride', () => {

--- a/tests/DefaultFormatter.spec.js
+++ b/tests/DefaultFormatter.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock Google Apps Script global CalendarApp
 global.CalendarApp = {
@@ -13,7 +13,9 @@ global.CalendarApp = {
     },
 };
 
-import { makeDefaultDescription, getActivityStyle } from '../formatters/DefaultFormatter';
+import { makeDefaultDescription, getActivityStyle, makeDescription } from '../formatters/DefaultFormatter';
+import { makeRideDescription } from '../formatters/RideFormatter';
+import { makeRunDescription } from '../formatters/RunFormatter';
 
 describe('DefaultFormatter', () => {
     describe('makeDefaultDescription', () => {
@@ -78,6 +80,59 @@ describe('DefaultFormatter', () => {
 
         it('should return default style for unknown type', () => {
             expect(getActivityStyle('Unknown')).toEqual({ emoji: '🏅', color: 'GRAY' });
+        });
+    });
+
+    describe('makeDescription', () => {
+        beforeEach(() => {
+            // makeDescription internally calls global makeRideDescription and makeRunDescription
+            // because in GAS they are in the same global scope.
+            // We mock them globally for tests to verify routing behavior.
+            global.makeRideDescription = vi.fn((activity) => `RIDE: ${activity.id}`);
+            global.makeRunDescription = vi.fn((activity) => `RUN: ${activity.id}`);
+        });
+
+        afterEach(() => {
+            delete global.makeRideDescription;
+            delete global.makeRunDescription;
+        });
+
+        it('should delegate to makeRideDescription for Ride', () => {
+            const activity = { type: 'Ride', id: 1 };
+            const result = makeDescription(activity);
+            expect(global.makeRideDescription).toHaveBeenCalledWith(activity);
+            expect(result).toBe('RIDE: 1');
+        });
+
+        it('should delegate to makeRideDescription for VirtualRide', () => {
+            const activity = { type: 'VirtualRide', id: 2 };
+            const result = makeDescription(activity);
+            expect(global.makeRideDescription).toHaveBeenCalledWith(activity);
+            expect(result).toBe('RIDE: 2');
+        });
+
+        it('should delegate to makeRunDescription for Run', () => {
+            const activity = { type: 'Run', id: 3 };
+            const result = makeDescription(activity);
+            expect(global.makeRunDescription).toHaveBeenCalledWith(activity);
+            expect(result).toBe('RUN: 3');
+        });
+
+        it('should delegate to makeRunDescription for Walk', () => {
+            const activity = { type: 'Walk', id: 4 };
+            const result = makeDescription(activity);
+            expect(global.makeRunDescription).toHaveBeenCalledWith(activity);
+            expect(result).toBe('RUN: 4');
+        });
+
+        it('should fall back to makeDefaultDescription for other types (e.g. Swim)', () => {
+            const activity = { type: 'Swim', id: 5, distance: 1000 };
+            const result = makeDescription(activity);
+            // Default description includes detailed formatting, we check part of it
+            expect(result).toContain('距離: 1.0 km');
+            expect(result).toContain('詳細: https://www.strava.com/activities/5');
+            expect(global.makeRideDescription).not.toHaveBeenCalled();
+            expect(global.makeRunDescription).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `makeDescription` function in `formatters/DefaultFormatter.js` was previously untested. This function acts as a router, directing the activity to the correct description generator (e.g. `makeRideDescription`, `makeRunDescription`, or `makeDefaultDescription`) based on the `type` property.

📊 **Coverage:** What scenarios are now tested
- Validates delegation to `makeRideDescription` when `activity.type` is 'Ride'.
- Validates delegation to `makeRideDescription` when `activity.type` is 'VirtualRide'.
- Validates delegation to `makeRunDescription` when `activity.type` is 'Run'.
- Validates delegation to `makeRunDescription` when `activity.type` is 'Walk'.
- Validates fallback behavior for unmatched types (e.g. 'Swim') falling back to `makeDefaultDescription`.

✨ **Result:** The improvement in test coverage
The routing logic for all major activity formats is now covered, providing confidence when adding new activity formats or refactoring existing routing paths. The tests mock the GAS global scope effectively.

---
*PR created automatically by Jules for task [17898477668396228268](https://jules.google.com/task/17898477668396228268) started by @kurousa*