### PR TITLE
🧪 Add tests for doGet function

### DIFF
--- a/main.js
+++ b/main.js
@@ -155,5 +155,6 @@ function doGet() {
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     sendErrorEmail,
+    doGet,
   };
 }

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { sendErrorEmail } from '../main';
+import { sendErrorEmail, doGet } from '../main';
 
 describe('main', () => {
     const mockUserProps = {
@@ -8,7 +8,7 @@ describe('main', () => {
     };
 
     beforeEach(() => {
-        vi.resetAllMocks();
+        vi.clearAllMocks();
         global.PropertiesService.getUserProperties.mockReturnValue(mockUserProps);
         global.Session.getEffectiveUser.mockReturnValue({
             getEmail: vi.fn(() => 'test@example.com')
@@ -57,5 +57,24 @@ describe('main', () => {
 
         expect(global.MailApp.sendEmail).not.toHaveBeenCalled();
         expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('スキップしました'));
+    });
+
+    describe('doGet', () => {
+        beforeEach(() => {
+            vi.clearAllMocks();
+        });
+
+        it('should create HTML output from index file and set title', () => {
+            const mockSetTitle = vi.fn().mockReturnThis();
+            global.HtmlService.createHtmlOutputFromFile.mockReturnValue({
+                setTitle: mockSetTitle
+            });
+
+            const result = doGet();
+
+            expect(global.HtmlService.createHtmlOutputFromFile).toHaveBeenCalledWith('index');
+            expect(mockSetTitle).toHaveBeenCalledWith('Strava カレンダーインポート');
+            expect(result).toBeDefined();
+        });
     });
 });

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -60,10 +60,6 @@ describe('main', () => {
     });
 
     describe('doGet', () => {
-        beforeEach(() => {
-            vi.clearAllMocks();
-        });
-
         it('should create HTML output from index file and set title', () => {
             const mockSetTitle = vi.fn().mockReturnThis();
             global.HtmlService.createHtmlOutputFromFile.mockReturnValue({

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -37,9 +37,12 @@ global.OAuth2 = {
 
 global.HtmlService = {
     createHtmlOutput: vi.fn(),
-    createHtmlOutputFromFile: vi.fn(() => ({
-        setTitle: vi.fn()
-    }))
+    createHtmlOutputFromFile: vi.fn(() => {
+        const mockOutput = {
+            setTitle: vi.fn().mockReturnThis(),
+        };
+        return mockOutput;
+    })
 };
 
 global.Session = {

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -36,7 +36,10 @@ global.OAuth2 = {
 };
 
 global.HtmlService = {
-    createHtmlOutput: vi.fn()
+    createHtmlOutput: vi.fn(),
+    createHtmlOutputFromFile: vi.fn(() => ({
+        setTitle: vi.fn()
+    }))
 };
 
 global.Session = {


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the `doGet` function in `main.js`, which is responsible for rendering the import HTML page in the web app.

📊 **Coverage:** 
- The target function is now properly exported in Node.js environments.
- The global `HtmlService` mock in `vitest.setup.js` has been updated to include `createHtmlOutputFromFile`, with support for method chaining (`setTitle`).
- A new test suite was added to `tests/main.spec.js` asserting that the file name and title passed to the Google Apps Script global object match expectations.
- Minor refactor in `tests/main.spec.js`: Replaced `vi.resetAllMocks()` with `vi.clearAllMocks()` inside the `beforeEach` hook to avoid overriding and unintentionally resetting the mock implementations set in `vitest.setup.js`.

✨ **Result:** 
Increased test coverage and confidence in the Web App initialization logic (`doGet`) by ensuring it successfully references the 'index' file and sets the correct title for the frontend without manually invoking Google Apps Script APIs.

---
*PR created automatically by Jules for task [5802446029741711059](https://jules.google.com/task/5802446029741711059) started by @kurousa*