### PR TITLE
🧪 Add tests for processActivityToCalendar

### DIFF
--- a/main.js
+++ b/main.js
@@ -157,5 +157,8 @@ if (typeof module !== 'undefined' && module.exports) {
     sendErrorEmail,
     doGet,
     getTargetCalendar,
+    processActivityToCalendar,
+    DISTANCE_ACTIVITIES,
+    CALENDAR_API_DELAY_MS,
   };
 }

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -130,3 +130,134 @@ describe('getTargetCalendar', () => {
         expect(result).toBe(mockDefaultCalendar);
     });
 });
+describe('processActivityToCalendar', () => {
+    let mockCalendar;
+    let mockEvent;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.resetModules();
+
+        mockEvent = {
+            getDescription: vi.fn(),
+            setColor: vi.fn(),
+        };
+
+        mockCalendar = {
+            getEvents: vi.fn().mockReturnValue([]),
+            createEvent: vi.fn().mockReturnValue(mockEvent)
+        };
+
+        global.Utilities.sleep = vi.fn();
+        global.Logger.log = vi.fn();
+    });
+
+    it('should skip creation if activity is already registered and skipDuplicateCheck is false', async () => {
+        mockEvent.getDescription.mockReturnValue('Some description with strava.com/activities/12345 inside');
+        mockCalendar.getEvents.mockReturnValue([mockEvent]);
+
+        const { processActivityToCalendar } = await import('../main.js');
+        const activity = {
+            id: 12345,
+            start_date: '2023-01-01T10:00:00Z',
+            elapsed_time: 3600
+        };
+
+        const result = processActivityToCalendar(activity, mockCalendar);
+
+        expect(mockCalendar.getEvents).toHaveBeenCalled();
+        expect(mockCalendar.createEvent).not.toHaveBeenCalled();
+        expect(result).toBe('skipped');
+        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('スキップ: 既に登録済みのアクティビティです'));
+    });
+
+    it('should create event with distance in title if type is in distanceActivities and distance > 0', async () => {
+        const { processActivityToCalendar, DISTANCE_ACTIVITIES, CALENDAR_API_DELAY_MS } = await import('../main.js');
+
+        const activity = {
+            id: 12345,
+            start_date: '2023-01-01T10:00:00Z',
+            elapsed_time: 3600,
+            type: 'Run', // In DISTANCE_ACTIVITIES
+            name: 'Morning Run',
+            distance: 5200 // 5.2 km
+        };
+
+        const result = processActivityToCalendar(activity, mockCalendar, DISTANCE_ACTIVITIES, false);
+
+        expect(mockCalendar.getEvents).toHaveBeenCalled();
+        expect(mockCalendar.createEvent).toHaveBeenCalledWith(
+            '[Run] Morning Run - 5.2km',
+            expect.any(Date),
+            expect.any(Date),
+            expect.any(Object)
+        );
+        expect(global.Utilities.sleep).toHaveBeenCalledWith(CALENDAR_API_DELAY_MS);
+        expect(result).toBe('success');
+    });
+
+    it('should create event without distance in title if distance is 0', async () => {
+        const { processActivityToCalendar, DISTANCE_ACTIVITIES } = await import('../main.js');
+
+        const activity = {
+            id: 12345,
+            start_date: '2023-01-01T10:00:00Z',
+            elapsed_time: 3600,
+            type: 'Run',
+            name: 'Treadmill Run',
+            distance: 0
+        };
+
+        const result = processActivityToCalendar(activity, mockCalendar, DISTANCE_ACTIVITIES, false);
+
+        expect(mockCalendar.createEvent).toHaveBeenCalledWith(
+            '[Run] Treadmill Run',
+            expect.any(Date),
+            expect.any(Date),
+            expect.any(Object)
+        );
+        expect(result).toBe('success');
+    });
+
+    it('should create event without distance in title if type is not in distanceActivities', async () => {
+        const { processActivityToCalendar, DISTANCE_ACTIVITIES } = await import('../main.js');
+
+        const activity = {
+            id: 12345,
+            start_date: '2023-01-01T10:00:00Z',
+            elapsed_time: 3600,
+            type: 'Yoga', // Not in DISTANCE_ACTIVITIES
+            name: 'Morning Yoga',
+            distance: 5000 // Even if distance is provided
+        };
+
+        const result = processActivityToCalendar(activity, mockCalendar, DISTANCE_ACTIVITIES, false);
+
+        expect(mockCalendar.createEvent).toHaveBeenCalledWith(
+            '[Yoga] Morning Yoga',
+            expect.any(Date),
+            expect.any(Date),
+            expect.any(Object)
+        );
+        expect(result).toBe('success');
+    });
+
+    it('should bypass duplicate check if skipDuplicateCheck is true', async () => {
+        const { processActivityToCalendar, DISTANCE_ACTIVITIES } = await import('../main.js');
+
+        const activity = {
+            id: 12345,
+            start_date: '2023-01-01T10:00:00Z',
+            elapsed_time: 3600,
+            type: 'Run',
+            name: 'Morning Run',
+            distance: 5200
+        };
+
+        const result = processActivityToCalendar(activity, mockCalendar, DISTANCE_ACTIVITIES, true);
+
+        expect(mockCalendar.getEvents).not.toHaveBeenCalled();
+        expect(mockCalendar.createEvent).toHaveBeenCalled();
+        expect(result).toBe('success');
+    });
+});

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -60,3 +60,25 @@ global.MailApp = {
 // Globalize DefaultFormatter for testing so that formatters can access it as they would in GAS environment
 import * as DefaultFormatter from './formatters/DefaultFormatter.js';
 global.getCommonMetrics = DefaultFormatter.getCommonMetrics || (() => ({}));
+
+// Utilitiesのモック
+global.Utilities = {
+    sleep: vi.fn(),
+};
+
+
+// Globalize formatter functions for main.js testing
+global.getActivityStyle = DefaultFormatter.getActivityStyle || (() => ({ color: "BLUE" }));
+global.makeDescription = DefaultFormatter.makeDescription || (() => "mock description");
+
+
+import * as RunFormatter from "./formatters/RunFormatter.js";
+import * as RideFormatter from "./formatters/RideFormatter.js";
+
+global.makeRunDescription = RunFormatter.makeRunDescription || (() => "mock run desc");
+global.makeRideDescription = RideFormatter.makeRideDescription || (() => "mock ride desc");
+
+
+// Restore original functions
+global.makeRunDescription = RunFormatter.makeRunDescription;
+global.makeRideDescription = RideFormatter.makeRideDescription;


### PR DESCRIPTION
🎯 **What:** Adds tests for `processActivityToCalendar` in `main.js`, covering how a Strava activity maps to a Google Calendar event. Includes mocking for `CalendarApp`, `Utilities.sleep`, and formatting globals.

📊 **Coverage:** 
- Skip duplicate events check when duplicate check isn't bypassed.
- Event title creation handling with and without distance metrics.
- Checking type existence in the `DISTANCE_ACTIVITIES` set.
- Duplicate check bypass `skipDuplicateCheck`.

✨ **Result:** Test coverage improved, and tests run successfully through vitest.

---
*PR created automatically by Jules for task [15613696336532139020](https://jules.google.com/task/15613696336532139020) started by @kurousa*