### PR TITLE
🧹 [Code Health] Remove redundant typeof check for sendErrorEmail

### DIFF
--- a/api.js
+++ b/api.js
@@ -15,7 +15,7 @@ function getStravaActivities(afterDate, beforeDate, perPage = 200) {
   if (!service.hasAccess()) {
     const errorMsg = 'Stravaと連携されていません。startAuthを実行してください。';
     Logger.log('エラー: ' + errorMsg);
-    if (typeof sendErrorEmail === 'function') sendErrorEmail(errorMsg);
+    sendErrorEmail(errorMsg);
     return [];
   }
 
@@ -75,7 +75,7 @@ function getStravaActivities(afterDate, beforeDate, perPage = 200) {
     } catch (e) {
       const errorMsg = 'Strava APIの呼び出しに失敗しました: ' + e.toString();
       Logger.log('エラー: ' + errorMsg);
-      if (typeof sendErrorEmail === 'function') sendErrorEmail(errorMsg);
+      sendErrorEmail(errorMsg);
       break;
     }
   }


### PR DESCRIPTION
## Description
🎯 **What:** Removed `typeof sendErrorEmail === 'function'` checks before calling `sendErrorEmail` in `api.js`.
💡 **Why:** This check was originally used as a workaround for Node.js testing environments, as Google Apps Script runs with a flat global scope where `sendErrorEmail` from `main.js` is implicitly available. However, since the test suite properly mocks `sendErrorEmail` on the global object (e.g. `vi.stubGlobal('sendErrorEmail', vi.fn())`), these checks are redundant. Removing them simplifies the code and improves readability without breaking functionality.
✅ **Verification:** Verified by ensuring the test suite passes locally using `pnpm test`.
✨ **Result:** Cleaner, more maintainable code with no change in functionality.

---
*PR created automatically by Jules for task [2188165582878598013](https://jules.google.com/task/2188165582878598013) started by @kurousa*