### PR TITLE
🔒 Fix date validation rollover vulnerability in manual import

### DIFF
--- a/manual_import.js
+++ b/manual_import.js
@@ -10,12 +10,21 @@ function importPastActivitiesFromWeb(startStr, endStr) {
         return msg;
     }
 
+    // Helper to validate date components to prevent rollover (e.g., 2024-02-31 -> 2024-03-02)
+    function isValidDateComponents(dateStr, dateObj) {
+        if (isNaN(dateObj.getTime())) return false;
+        const [y, m, d] = dateStr.split('-');
+        return dateObj.getFullYear() === parseInt(y, 10) &&
+               dateObj.getMonth() + 1 === parseInt(m, 10) &&
+               dateObj.getDate() === parseInt(d, 10);
+    }
+
     // 画面からの文字列(YYYY-MM-DD)をDateオブジェクトに変換
     const startDate = new Date(`${startStr}T00:00:00`);
     const endDate = new Date(`${endStr}T23:59:59`);
 
     // Check if dates are valid
-    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+    if (!isValidDateComponents(startStr, startDate) || !isValidDateComponents(endStr, endDate)) {
         const msg = 'エラー: 無効な日付が指定されました。';
         Logger.log(msg);
         return msg;

--- a/tests/manual_import.spec.js
+++ b/tests/manual_import.spec.js
@@ -156,6 +156,14 @@ describe('importPastActivitiesFromWeb', () => {
         expect(global.Logger.log).toHaveBeenCalledWith('エラー: 無効な日付が指定されました。');
     });
 
+    it('should reject invalid dates with rollover', () => {
+        const result1 = importPastActivitiesFromWeb('2024-02-31', '2024-03-31');
+        expect(result1).toBe('エラー: 無効な日付が指定されました。');
+
+        const result2 = importPastActivitiesFromWeb('2024-11-31', '2024-12-01');
+        expect(result2).toBe('エラー: 無効な日付が指定されました。');
+    });
+
     it('should reject date ranges where start is after end', () => {
         const result = importPastActivitiesFromWeb('2024-01-31', '2024-01-01');
         expect(result).toBe('エラー: 開始日は終了日より前の日付を指定してください。');


### PR DESCRIPTION
🎯 **What:** The manual import function validated date strings via a simple regex and an `isNaN(date.getTime())` check. However, JavaScript's Date constructor rolls over invalid days (e.g., '2024-02-31' becomes '2024-03-02'), circumventing the `isNaN` check.
⚠️ **Risk:** Allowed invalid date strings to silently execute, potentially leading to unexpected boundary data imports or confusion regarding calendar data integrity.
🛡️ **Solution:** Added a manual validation helper `isValidDateComponents` that ensures the parsed Date object strictly matches the provided year, month, and day components, explicitly preventing automatic rollover.

---
*PR created automatically by Jules for task [17479394915924517232](https://jules.google.com/task/17479394915924517232) started by @kurousa*