### PR TITLE
🔒 [security fix] Redact sensitive info from API error logs

### DIFF
--- a/api.js
+++ b/api.js
@@ -47,7 +47,8 @@ function getStravaActivities(afterDate, beforeDate, perPage = 200) {
       });
 
       if (response.getResponseCode() !== 200) {
-        Logger.log(`[API Error] ${response.getContentText()}`);
+        // セキュリティのため、生のエラーレスポンスはログに出力せず、ステータスコードのみ記録します
+        Logger.log(`[API Error] Status Code: ${response.getResponseCode()}`);
         break; // エラー時はループを抜ける
       }
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the logging of raw API error responses without redaction in `api.js`.

⚠️ **Risk:** API error responses, especially in OAuth flows, can contain sensitive information such as access tokens, refresh tokens, personally identifiable information (PII), or internal system details. Logging this data exposes it to anyone with access to the application logs, increasing the risk of credential theft or privacy breaches.

🛡️ **Solution:** Modified the error handling logic in `getStravaActivities` to log only the HTTP status code using `response.getResponseCode()` instead of the full response content via `response.getContentText()`. This provides enough information for basic troubleshooting while ensuring that sensitive data is not leaked into the logs.

---
*PR created automatically by Jules for task [17946713782926563516](https://jules.google.com/task/17946713782926563516) started by @kurousa*