### PR TITLE
⚡ Optimize Calendar API Query in main()

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,9 +21,10 @@ const DISTANCE_ACTIVITIES = new Set([
  */
 function main() {
   // 実行時刻の1日前から現在時刻までのアクティビティを取得
+  const now = new Date();
   const yesterday = new Date();
   yesterday.setDate(yesterday.getDate() - 1);
-  const activities = getStravaActivities(yesterday, new Date());
+  const activities = getStravaActivities(yesterday, now);
   if (activities.length === 0) {
     Logger.log('登録するアクティビティがありませんでした。');
     return;
@@ -38,8 +39,28 @@ function main() {
   }
   Logger.log(`[DEBUG]登録先calendar: ${calendar.getName()}`);
 
+  // ⚡ Bolt Optimization: Batch load existing events to avoid N+1 queries
+  const existingEvents = calendar.getEvents(yesterday, now);
+  const existingActivityIds = new Set();
+  existingEvents.forEach(event => {
+    const desc = event.getDescription();
+    if (desc) {
+      const match = desc.match(/strava\.com\/activities\/(\d+)/);
+      if (match && match[1]) {
+        existingActivityIds.add(match[1]);
+      }
+    }
+  });
+
   activities.forEach(activity => {
-    processActivityToCalendar(activity, calendar);
+    const activityIdStr = String(activity.id);
+    if (existingActivityIds.has(activityIdStr)) {
+      Logger.log(`スキップ: 既に登録済みのアクティビティです: ${activity.id}`);
+      return;
+    }
+
+    // ⚡ Bolt: Pass skipDuplicateCheck=true because we already filtered duplicates above
+    processActivityToCalendar(activity, calendar, undefined, true);
   });
 }
 


### PR DESCRIPTION
### 💡 What:
Optimized the `main()` function in `main.js` to eliminate a performance bottleneck where the Google Calendar API was queried for every individual Strava activity.

### 🎯 Why:
The original code had an N+1 query pattern, calling `calendar.getEvents(startTime, endTime)` inside a loop for each activity. This is highly inefficient in Google Apps Script, where API calls are slow and can lead to execution time limit exceeded errors.

### 📊 Measured Improvement:
Using a custom verification script that mocks the Google Apps Script environment, I measured the following:
- **Baseline:** 2 `getEvents` calls for 2 activities.
- **Optimized:** 1 `getEvents` call regardless of the number of activities.
- **Result:** Reduced API complexity from O(N) to O(1). In a typical daily run with multiple activities, this will significantly reduce execution time and API quota usage.

Verified functionality via custom script and validated syntax with `node -c`.

---
*PR created automatically by Jules for task [3753626786124341386](https://jules.google.com/task/3753626786124341386) started by @kurousa*