### PR TITLE
🧹 [Code Health] Change let to const for descriptionLines array

### DIFF
--- a/formatters/DefaultFormatter.js
+++ b/formatters/DefaultFormatter.js
@@ -14,7 +14,7 @@ function getCommonMetrics(activity) {
 // 汎用 (その他) のフォーマット処理
 // ==========================================
 function makeDefaultDescription(activity) {
-  let descriptionLines = [];
+  const descriptionLines = [];
 
   // 距離 (0より大きければ追加)
   if (activity.distance && activity.distance > 0) {


### PR DESCRIPTION
🎯 **What:** Changed `let descriptionLines = []` to `const descriptionLines = []` in `formatters/DefaultFormatter.js`.

💡 **Why:** The `descriptionLines` array is mutated via `.push()` but its reference is never reassigned. Using `const` makes the code's intent clearer and ensures the array reference is not accidentally reassigned elsewhere, improving code health and maintainability.

✅ **Verification:**
- Ran full test suite (`pnpm test`), all tests passed.

✨ **Result:** Improved clarity and maintainability by preventing accidental reassignment of the array variable.

---
*PR created automatically by Jules for task [9512562039520910917](https://jules.google.com/task/9512562039520910917) started by @kurousa*