### PR TITLE
🧹 Remove redundant truthy checks for numeric activity metrics

### DIFF
--- a/formatters/DefaultFormatter.js
+++ b/formatters/DefaultFormatter.js
@@ -17,19 +17,19 @@ function makeDefaultDescription(activity) {
   let descriptionLines = [];
 
   // 距離 (0より大きければ追加)
-  if (activity.distance && activity.distance > 0) {
+  if (activity.distance > 0) {
     const distanceKm = (activity.distance / 1000).toFixed(1);
     descriptionLines.push(`距離: ${distanceKm} km`);
   }
 
   // 時間 (0より大きければ追加)
-  if (activity.moving_time && activity.moving_time > 0) {
+  if (activity.moving_time > 0) {
     const timeMin = Math.floor(activity.moving_time / 60);
     descriptionLines.push(`時間: ${timeMin} 分`);
   }
 
   // 獲得標高 (0より大きければ追加)
-  if (activity.total_elevation_gain && activity.total_elevation_gain > 0) {
+  if (activity.total_elevation_gain > 0) {
     descriptionLines.push(`獲得標高: ${activity.total_elevation_gain} m`);
   }
 


### PR DESCRIPTION
🎯 **What:** Removed redundant truthy checks (e.g. `activity.distance && activity.distance > 0`) in `formatters/DefaultFormatter.js`. The checks have been simplified to just `> 0` comparison.
💡 **Why:** JavaScript's `> 0` safely evaluates to false for falsy values like `undefined`, `null`, and `NaN`. Removing the redundant truthy check simplifies the code and improves readability.
✅ **Verification:** Ran `pnpm test` and confirmed all 68 tests pass without issues.
✨ **Result:** Code is cleaner and more concise while maintaining identical behavior.

---
*PR created automatically by Jules for task [11785014351475264810](https://jules.google.com/task/11785014351475264810) started by @kurousa*