### PR TITLE
🧹 Remove redundant truthy checks in DefaultFormatter

### DIFF
--- a/formatters/DefaultFormatter.js
+++ b/formatters/DefaultFormatter.js
@@ -17,19 +17,19 @@ function makeDefaultDescription(activity) {
   let descriptionLines = [];
 
   // 距離 (0より大きければ追加)
-  if (activity.distance && activity.distance > 0) {
+  if (activity.distance > 0) {
     const distanceKm = (activity.distance / 1000).toFixed(1);
     descriptionLines.push(`距離: ${distanceKm} km`);
   }
 
   // 時間 (0より大きければ追加)
-  if (activity.moving_time && activity.moving_time > 0) {
+  if (activity.moving_time > 0) {
     const timeMin = Math.floor(activity.moving_time / 60);
     descriptionLines.push(`時間: ${timeMin} 分`);
   }
 
   // 獲得標高 (0より大きければ追加)
-  if (activity.total_elevation_gain && activity.total_elevation_gain > 0) {
+  if (activity.total_elevation_gain > 0) {
     descriptionLines.push(`獲得標高: ${activity.total_elevation_gain} m`);
   }
 


### PR DESCRIPTION
🎯 **What:** Removed redundant truthy checks before `> 0` comparisons for `activity.distance`, `activity.moving_time`, and `activity.total_elevation_gain` in `formatters/DefaultFormatter.js`.
💡 **Why:** Relational operators like `> 0` safely return `false` for `undefined` and `null` in JavaScript. The truthy checks were redundant and added visual noise.
✅ **Verification:** Ran the full test suite using `pnpm test`, which passed successfully. The logic is identical.
✨ **Result:** Improved code readability and maintainability without altering functionality.

---
*PR created automatically by Jules for task [7986136375388020668](https://jules.google.com/task/7986136375388020668) started by @kurousa*