### PR TITLE
🧹 [code health improvement] extract pace calculation logic

### DIFF
--- a/formatters/RunFormatter.js
+++ b/formatters/RunFormatter.js
@@ -1,20 +1,26 @@
 // ==========================================
 // ラン・ウォーク (Run / Walk) 専用のフォーマット処理
 // ==========================================
+function formatPace(averageSpeed) {
+	if (!averageSpeed || averageSpeed <= 0) {
+		return "測定なし";
+	}
+	const secondsPerKm = 1000 / averageSpeed;
+	const paceMin = Math.floor(secondsPerKm / 60);
+	const paceSec = Math.floor(secondsPerKm % 60)
+		.toString()
+		.padStart(2, "0");
+	return `${paceMin}'${paceSec}" /km`;
+}
+
 function makeRunDescription(activity) {
-  // 共通のメトリクス計算 (DefaultFormatter.js で定義、GAS環境/vitestでグローバル解決)
-  const { distanceKm, timeMin, elevation, hr } = getCommonMetrics(activity);
+	// 共通のメトリクス計算 (DefaultFormatter.js で定義、GAS環境/vitestでグローバル解決)
+	const { distanceKm, timeMin, elevation, hr } = getCommonMetrics(activity);
 
-  // ラン専用の計算（ペース）
-  let paceText = '測定なし';
-  if (activity.average_speed > 0) {
-    const secondsPerKm = 1000 / activity.average_speed;
-    const paceMin = Math.floor(secondsPerKm / 60);
-    const paceSec = Math.floor(secondsPerKm % 60).toString().padStart(2, '0');
-    paceText = `${paceMin}'${paceSec}" /km`;
-  }
+	// ラン専用の計算（ペース）
+	const paceText = formatPace(activity.average_speed);
 
-  return `
+	return `
 距離: ${distanceKm} km
 時間: ${timeMin} 分
 ペース: ${paceText}
@@ -26,8 +32,9 @@ function makeRunDescription(activity) {
 }
 
 // Node.js環境（テスト時）のみエクスポートする
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = {
-    makeRunDescription,
-  };
+if (typeof module !== "undefined" && module.exports) {
+	module.exports = {
+		formatPace,
+		makeRunDescription,
+	};
 }

--- a/tests/RunFormatter.spec.js
+++ b/tests/RunFormatter.spec.js
@@ -1,20 +1,21 @@
-import { describe, it, expect } from 'vitest';
-import { makeRunDescription } from '../formatters/RunFormatter';
+import { describe, it, expect } from "vitest";
+import { makeRunDescription, formatPace } from "../formatters/RunFormatter";
 
-describe('RunFormatter', () => {
-    it('should format run description with pace and heart rate', () => {
-        const activity = {
-            id: 111111,
-            distance: 10000, // 10km
-            moving_time: 3000, // 50 min
-            total_elevation_gain: 100,
-            has_heartrate: true,
-            average_heartrate: 156,
-            average_speed: 3.3333, // ~5:00/km (1000 / 3.3333 = 300 seconds)
-        };
+describe("RunFormatter", () => {
+	it("should format run description with pace and heart rate", () => {
+		const activity = {
+			id: 111111,
+			distance: 10000, // 10km
+			moving_time: 3000, // 50 min
+			total_elevation_gain: 100,
+			has_heartrate: true,
+			average_heartrate: 156,
+			average_speed: 3.3333, // ~5:00/km (1000 / 3.3333 = 300 seconds)
+		};
 
-        const result = makeRunDescription(activity);
-        expect(result).toBe(`
+		const result = makeRunDescription(activity);
+		expect(result).toBe(
+			`
 距離: 10.0 km
 時間: 50 分
 ペース: 5'00" /km
@@ -22,21 +23,23 @@ describe('RunFormatter', () => {
 平均心拍数: 156 bpm
 
 詳細: https://www.strava.com/activities/111111
-        `.trim());
-    });
+        `.trim(),
+		);
+	});
 
-    it('should format run description without heart rate and speed', () => {
-        const activity = {
-            id: 222222,
-            distance: 5000,
-            moving_time: 1500,
-            total_elevation_gain: 0,
-            has_heartrate: false,
-            average_speed: 0
-        };
+	it("should format run description without heart rate and speed", () => {
+		const activity = {
+			id: 222222,
+			distance: 5000,
+			moving_time: 1500,
+			total_elevation_gain: 0,
+			has_heartrate: false,
+			average_speed: 0,
+		};
 
-        const result = makeRunDescription(activity);
-        expect(result).toBe(`
+		const result = makeRunDescription(activity);
+		expect(result).toBe(
+			`
 距離: 5.0 km
 時間: 25 分
 ペース: 測定なし
@@ -44,6 +47,20 @@ describe('RunFormatter', () => {
 平均心拍数: 測定なし
 
 詳細: https://www.strava.com/activities/222222
-        `.trim());
-    });
+        `.trim(),
+		);
+	});
+});
+
+describe("formatPace", () => {
+	it("should format pace correctly when averageSpeed > 0", () => {
+		expect(formatPace(3.3333)).toBe("5'00\" /km");
+		expect(formatPace(2.5)).toBe("6'40\" /km"); // 400 sec
+	});
+
+	it('should return "測定なし" when averageSpeed is 0 or missing', () => {
+		expect(formatPace(0)).toBe("測定なし");
+		expect(formatPace(undefined)).toBe("測定なし");
+		expect(formatPace(null)).toBe("測定なし");
+	});
 });


### PR DESCRIPTION
🎯 **What:** Extracted the pace calculation logic from `makeRunDescription` into a separate `formatPace` function.

💡 **Why:** This replaces the mutable state assignment (`let paceText = '測定なし';`) with a function call. It makes the code easier to read, test, and maintain.

✅ **Verification:** Unit tests were written for the new `formatPace` function to verify edge cases. Total test suite is passing with high coverage. Linting and formatting were applied to the changed files.

✨ **Result:** Improved maintainability while preserving the same behavioral outputs.

---
*PR created automatically by Jules for task [12297415297324926844](https://jules.google.com/task/12297415297324926844) started by @kurousa*