### PR TITLE
Add Discord Notifications for Sync Completion

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -52,24 +52,35 @@ function main(): void {
         }
     });
 
+    let successCount = 0;
+    let skipCount = 0;
     const successfulActivities: StravaActivity[] = [];
-    
+
     activities.forEach(activity => {
         const activityIdStr = String(activity.id);
         if (existingActivityIds.has(activityIdStr)) {
             Logger.log(`スキップ: 既に登録済みのアクティビティです: ${activity.id}`);
+            skipCount++;
             return;
         }
 
         // ⚡ Bolt: Pass skipDuplicateCheck=true because we already filtered duplicates above
         const result = processActivityToCalendar(activity, calendar, undefined, true);
         if (result === 'success') {
+            successCount++;
             successfulActivities.push(activity);
+        } else if (result === 'skipped') {
+            skipCount++;
         }
     });
 
     if (typeof backupToSpreadsheet === 'function') {
         backupToSpreadsheet(successfulActivities);
+    }
+
+    // 同期結果を通知する
+    if (typeof sendSyncNotification === 'function') {
+        sendSyncNotification(successCount, skipCount, false);
     }
 }
 

--- a/manual_import.ts
+++ b/manual_import.ts
@@ -111,6 +111,11 @@ function importPastActivities(startDate?: Date, endDate?: Date, perPage: number 
         backupToSpreadsheet(successfulActivities);
     }
 
+    // 同期結果を通知する
+    if (typeof sendSyncNotification === 'function') {
+        sendSyncNotification(successCount, skipCount, true);
+    }
+
     const resultMsg = `✅ 完了! 新規登録: ${successCount}件 / スキップ: ${skipCount}件`;
     Logger.log(resultMsg);
     return resultMsg;

--- a/notifier.ts
+++ b/notifier.ts
@@ -1,0 +1,61 @@
+// ==========================================
+// 通知処理の役割 (notifier.ts)
+// 外部サービス (Discord等) へ同期結果を送信します
+// ==========================================
+
+let DISCORD_WEBHOOK_URL_CACHE: string | null = null;
+
+/**
+ * 同期結果を外部サービスへ通知する
+ */
+function sendSyncNotification(successCount: number, skipCount: number, isManual: boolean = false): void {
+    if (DISCORD_WEBHOOK_URL_CACHE === null) {
+        DISCORD_WEBHOOK_URL_CACHE = PropertiesService.getScriptProperties().getProperty('DISCORD_WEBHOOK_URL') || '';
+    }
+
+    if (!DISCORD_WEBHOOK_URL_CACHE) {
+        Logger.log('DISCORD_WEBHOOK_URL が設定されていないため、通知をスキップします。');
+        return;
+    }
+
+    // 処理件数が0件の場合は通知しない（不要であればコメントアウトしてください）
+    if (successCount === 0 && skipCount === 0) {
+        return;
+    }
+
+    const modeText = isManual ? "手動インポート" : "定期同期";
+    const message = `✅ **Strava カレンダー${modeText}完了**\n新規登録: ${successCount}件 / スキップ: ${skipCount}件`;
+
+    const payload = {
+        content: message
+    };
+
+    const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
+        method: 'post',
+        contentType: 'application/json',
+        payload: JSON.stringify(payload),
+        muteHttpExceptions: true
+    };
+
+    try {
+        const response = UrlFetchApp.fetch(DISCORD_WEBHOOK_URL_CACHE, options);
+        // DiscordのWebhookは成功時に204(No Content)を返すことが多いです
+        if (response.getResponseCode() !== 200 && response.getResponseCode() !== 204) {
+            Logger.log(`[Notification Error] ${response.getContentText()}`);
+        } else {
+            Logger.log('Discordへの通知が完了しました。');
+        }
+    } catch (e) {
+        Logger.log(`[Notification Exception] 通知の送信に失敗しました: ${e}`);
+    }
+}
+
+// Node.js環境（テスト時）のみエクスポートする
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        sendSyncNotification,
+        get DISCORD_WEBHOOK_URL_CACHE() { return DISCORD_WEBHOOK_URL_CACHE; },
+        set DISCORD_WEBHOOK_URL_CACHE(val) { DISCORD_WEBHOOK_URL_CACHE = val; },
+        resetCache: () => { DISCORD_WEBHOOK_URL_CACHE = null; }
+    };
+}

--- a/tests/notifier.spec.ts
+++ b/tests/notifier.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendSyncNotification, resetCache } from '../notifier.ts';
+
+describe('notifier', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        if (typeof resetCache === 'function') resetCache();
+    });
+
+    it('should skip notification if DISCORD_WEBHOOK_URL is not set', () => {
+        const getPropertyMock = vi.mocked(global.PropertiesService.getScriptProperties().getProperty).mockReturnValue(null);
+
+        sendSyncNotification(1, 1, false);
+
+        expect(global.Logger.log).toHaveBeenCalledWith('DISCORD_WEBHOOK_URL が設定されていないため、通知をスキップします。');
+        expect(global.UrlFetchApp.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should not notify if both counts are 0', () => {
+        vi.mocked(global.PropertiesService.getScriptProperties().getProperty).mockReturnValue('https://discord.com/api/webhooks/mock');
+
+        sendSyncNotification(0, 0, false);
+
+        expect(global.UrlFetchApp.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should send notification to Discord with correct message (periodic)', () => {
+        vi.mocked(global.PropertiesService.getScriptProperties().getProperty).mockReturnValue('https://discord.com/api/webhooks/mock');
+        vi.mocked(global.UrlFetchApp.fetch).mockReturnValue({
+            getResponseCode: () => 204,
+            getContentText: () => ''
+        } as any);
+
+        sendSyncNotification(5, 2, false);
+
+        expect(global.UrlFetchApp.fetch).toHaveBeenCalledWith(
+            'https://discord.com/api/webhooks/mock',
+            expect.objectContaining({
+                method: 'post',
+                contentType: 'application/json',
+                payload: JSON.stringify({
+                    content: '✅ **Strava カレンダー定期同期完了**\n新規登録: 5件 / スキップ: 2件'
+                })
+            })
+        );
+        expect(global.Logger.log).toHaveBeenCalledWith('Discordへの通知が完了しました。');
+    });
+
+    it('should send notification to Discord with correct message (manual)', () => {
+        vi.mocked(global.PropertiesService.getScriptProperties().getProperty).mockReturnValue('https://discord.com/api/webhooks/mock');
+        vi.mocked(global.UrlFetchApp.fetch).mockReturnValue({
+            getResponseCode: () => 204,
+            getContentText: () => ''
+        } as any);
+
+        sendSyncNotification(3, 0, true);
+
+        expect(global.UrlFetchApp.fetch).toHaveBeenCalledWith(
+            'https://discord.com/api/webhooks/mock',
+            expect.objectContaining({
+                payload: JSON.stringify({
+                    content: '✅ **Strava カレンダー手動インポート完了**\n新規登録: 3件 / スキップ: 0件'
+                })
+            })
+        );
+    });
+
+    it('should log error if response code is not 200 or 204', () => {
+        vi.mocked(global.PropertiesService.getScriptProperties().getProperty).mockReturnValue('https://discord.com/api/webhooks/mock');
+        vi.mocked(global.UrlFetchApp.fetch).mockReturnValue({
+            getResponseCode: () => 400,
+            getContentText: () => 'Bad Request'
+        } as any);
+
+        sendSyncNotification(1, 0, false);
+
+        expect(global.Logger.log).toHaveBeenCalledWith('[Notification Error] Bad Request');
+    });
+
+    it('should log exception if fetch fails', () => {
+        vi.mocked(global.PropertiesService.getScriptProperties().getProperty).mockReturnValue('https://discord.com/api/webhooks/mock');
+        vi.mocked(global.UrlFetchApp.fetch).mockImplementation(() => {
+            throw new Error('Network Error');
+        });
+
+        sendSyncNotification(1, 0, false);
+
+        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('[Notification Exception] 通知の送信に失敗しました: Error: Network Error'));
+    });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -26,14 +26,16 @@ global.SpreadsheetApp = {
     }))
 } as any;
 
+const scriptPropertiesMock = {
+    getProperty: vi.fn((key: string) => {
+        if (key === 'STRAVA_CLIENT_ID') return 'fake_id';
+        if (key === 'STRAVA_CLIENT_SECRET') return 'fake_secret';
+        return null;
+    })
+};
+
 global.PropertiesService = {
-    getScriptProperties: vi.fn(() => ({
-        getProperty: vi.fn((key: string) => {
-            if (key === 'STRAVA_CLIENT_ID') return 'fake_id';
-            if (key === 'STRAVA_CLIENT_SECRET') return 'fake_secret';
-            return null;
-        })
-    })),
+    getScriptProperties: vi.fn(() => scriptPropertiesMock),
     getUserProperties: vi.fn(() => ({
         getProperty: vi.fn(),
         setProperty: vi.fn()
@@ -64,6 +66,10 @@ global.MailApp = {
     sendEmail: vi.fn()
 } as any;
 
+global.UrlFetchApp = {
+    fetch: vi.fn(),
+} as any;
+
 // Globalize DefaultFormatter for testing so that formatters can access it as they would in GAS environment
 import * as DefaultFormatter from './formatters/DefaultFormatter.ts';
 global.getCommonMetrics = (DefaultFormatter as any).getCommonMetrics || (() => ({}));
@@ -89,3 +95,7 @@ global.makeRideDescription = (RideFormatter as any).makeRideDescription || (() =
 // Restore original functions
 global.makeRunDescription = (RunFormatter as any).makeRunDescription;
 global.makeRideDescription = (RideFormatter as any).makeRideDescription;
+
+import * as NotifierModule from './notifier.ts';
+global.sendSyncNotification = (NotifierModule as any).sendSyncNotification || vi.fn();
+// We don't globalize DISCORD_WEBHOOK_URL_CACHE here because we want to test the module internal state

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -97,5 +97,5 @@ global.makeRunDescription = (RunFormatter as any).makeRunDescription;
 global.makeRideDescription = (RideFormatter as any).makeRideDescription;
 
 import * as NotifierModule from './notifier.ts';
-global.sendSyncNotification = (NotifierModule as any).sendSyncNotification || vi.fn();
+vi.stubGlobal('sendSyncNotification', (NotifierModule as any).sendSyncNotification || vi.fn());
 // We don't globalize DISCORD_WEBHOOK_URL_CACHE here because we want to test the module internal state

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -66,9 +66,9 @@ global.MailApp = {
     sendEmail: vi.fn()
 } as any;
 
-global.UrlFetchApp = {
+vi.stubGlobal('UrlFetchApp', {
     fetch: vi.fn(),
-} as any;
+});
 
 // Globalize DefaultFormatter for testing so that formatters can access it as they would in GAS environment
 import * as DefaultFormatter from './formatters/DefaultFormatter.ts';


### PR DESCRIPTION
This change adds a notification feature that sends synchronization results (number of activities added and skipped) to a Discord channel via Webhooks. It integrates with both the daily automatic sync and the manual import process.

Key changes:
- Created `notifier.ts` for handling external notifications.
- Modified `main.ts` to count successful and skipped activities during the daily sync.
- Integrated notification calls in `main.ts` and `manual_import.ts`.
- Added a comprehensive test suite for `notifier.ts`.
- Updated global mocks in `vitest.setup.ts`.

Fixes #65

---
*PR created automatically by Jules for task [5531469654487145706](https://jules.google.com/task/5531469654487145706) started by @kurousa*