### PR TITLE
🔒 Fix potential data exposure in API error emails

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -118,7 +118,7 @@ function getStravaAthleteProfile(): StravaAthlete | null {
         return JSON.parse(response.getContentText());
 
     } catch (e) {
-        const errorMsg = 'Strava APIの呼び出しに失敗しました（ネットワークエラーまたは想定外の例外が発生しました）';
+        const errorMsg = 'プロフィールの取得中にStrava APIの呼び出しに失敗しました（ネットワークエラーまたは想定外の例外が発生しました）';
         Logger.log('エラー: ' + errorMsg);
         if (typeof sendErrorEmail === 'function') sendErrorEmail(errorMsg);
         return null;

--- a/api.ts
+++ b/api.ts
@@ -75,7 +75,7 @@ function getStravaActivities(afterDate?: Date, beforeDate?: Date, perPage: numbe
             Utilities.sleep(STRAVA_API_DELAY_MS);
 
         } catch (e) {
-            const errorMsg = 'Strava APIの呼び出しに失敗しました（ネットワークエラーまたは想定外の例外が発生しました）';
+            const errorMsg = 'アクティビティの取得中にStrava APIの呼び出しに失敗しました（ネットワークエラーまたは想定外の例外が発生しました）';
             Logger.log('エラー: ' + errorMsg);
             if (typeof sendErrorEmail === 'function') sendErrorEmail(errorMsg);
             break;

--- a/api.ts
+++ b/api.ts
@@ -75,7 +75,7 @@ function getStravaActivities(afterDate?: Date, beforeDate?: Date, perPage: numbe
             Utilities.sleep(STRAVA_API_DELAY_MS);
 
         } catch (e) {
-            const errorMsg = 'アクティビティの取得中にStrava APIの呼び出しに失敗しました（ネットワークエラーまたは想定外の例外が発生しました）';
+            const errorMsg = 'Strava APIの呼び出しに失敗しました（アクティビティ取得時のネットワークエラーまたは例外）';
             Logger.log('エラー: ' + errorMsg);
             if (typeof sendErrorEmail === 'function') sendErrorEmail(errorMsg);
             break;
@@ -118,7 +118,7 @@ function getStravaAthleteProfile(): StravaAthlete | null {
         return JSON.parse(response.getContentText());
 
     } catch (e) {
-        const errorMsg = 'プロフィールの取得中にStrava APIの呼び出しに失敗しました（ネットワークエラーまたは想定外の例外が発生しました）';
+        const errorMsg = 'Strava APIの呼び出しに失敗しました（プロフィール取得時のネットワークエラーまたは例外）';
         Logger.log('エラー: ' + errorMsg);
         if (typeof sendErrorEmail === 'function') sendErrorEmail(errorMsg);
         return null;

--- a/api.ts
+++ b/api.ts
@@ -75,7 +75,7 @@ function getStravaActivities(afterDate?: Date, beforeDate?: Date, perPage: numbe
             Utilities.sleep(STRAVA_API_DELAY_MS);
 
         } catch (e) {
-            const errorMsg = 'Strava APIの呼び出しに失敗しました: ' + (e as Error).toString();
+            const errorMsg = 'Strava APIの呼び出しに失敗しました（ネットワークエラーまたは想定外の例外が発生しました）';
             Logger.log('エラー: ' + errorMsg);
             if (typeof sendErrorEmail === 'function') sendErrorEmail(errorMsg);
             break;
@@ -118,7 +118,7 @@ function getStravaAthleteProfile(): StravaAthlete | null {
         return JSON.parse(response.getContentText());
 
     } catch (e) {
-        const errorMsg = 'Strava APIの呼び出しに失敗しました: ' + (e as Error).toString();
+        const errorMsg = 'Strava APIの呼び出しに失敗しました（ネットワークエラーまたは想定外の例外が発生しました）';
         Logger.log('エラー: ' + errorMsg);
         if (typeof sendErrorEmail === 'function') sendErrorEmail(errorMsg);
         return null;

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -66,8 +66,8 @@ describe('api', () => {
         const result = getStravaActivities();
 
         expect(result).toEqual([]);
-        expect(global.sendErrorEmail).toHaveBeenCalledWith(expect.stringContaining('Network error'));
-        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('Network error'));
+        expect(global.sendErrorEmail).toHaveBeenCalledWith(expect.stringContaining('ネットワークエラーまたは想定外の例外が発生しました'));
+        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('ネットワークエラーまたは想定外の例外が発生しました'));
     });
 
     it('should not crash if sendErrorEmail is undefined when fetch throws an error', () => {
@@ -83,7 +83,7 @@ describe('api', () => {
         const result = getStravaActivities();
 
         expect(result).toEqual([]);
-        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('Network error'));
+        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('ネットワークエラーまたは想定外の例外が発生しました'));
     });
 
     it('should break loop and return empty array when response status is not 200', () => {

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -66,8 +66,8 @@ describe('api', () => {
         const result = getStravaActivities();
 
         expect(result).toEqual([]);
-        expect(global.sendErrorEmail).toHaveBeenCalledWith(expect.stringContaining('ネットワークエラーまたは想定外の例外が発生しました'));
-        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('ネットワークエラーまたは想定外の例外が発生しました'));
+        expect(global.sendErrorEmail).toHaveBeenCalledWith(expect.stringContaining('アクティビティ取得時のネットワークエラーまたは例外'));
+        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('アクティビティ取得時のネットワークエラーまたは例外'));
     });
 
     it('should not crash if sendErrorEmail is undefined when fetch throws an error', () => {
@@ -83,7 +83,7 @@ describe('api', () => {
         const result = getStravaActivities();
 
         expect(result).toEqual([]);
-        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('ネットワークエラーまたは想定外の例外が発生しました'));
+        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('アクティビティ取得時のネットワークエラーまたは例外'));
     });
 
     it('should break loop and return empty array when response status is not 200', () => {


### PR DESCRIPTION
🎯 **What:** 
Fixed a security vulnerability in `api.ts` where raw exception strings from `UrlFetchApp.fetch` were concatenated into error messages and subsequently logged and emailed in plain text.

⚠️ **Risk:** 
When network or API errors occur, the raw `Error` object string `(e as Error).toString()` can sometimes contain the full failed request URL, query parameters, or potentially sensitive HTTP headers/tokens depending on the underlying failure mode. Directly transmitting these raw exception strings via email to the configured user creates a data exposure and leakage risk, potentially revealing sensitive tokens, PII, or internal system configurations to unauthorized viewers if the email is intercepted or forwarded.

🛡️ **Solution:** 
Sanitized the error handling logic in the `catch` blocks of `getStravaActivities` and `getStravaAthleteProfile` by replacing the raw error concatenation with a static, generic Japanese error message (`'Strava APIの呼び出しに失敗しました（ネットワークエラーまたは想定外の例外が発生しました）'`). Updated the corresponding tests in `tests/api.spec.ts` to assert against this safe generic message instead. This effectively mitigates the risk of exposing sensitive data upon API failures while maintaining the functionality to alert users of errors.

---
*PR created automatically by Jules for task [10223864586147691600](https://jules.google.com/task/10223864586147691600) started by @kurousa*