### PR TITLE
🧪 Add test case for negative averageSpeed in RunFormatter

### DIFF
--- a/tests/RunFormatter.spec.ts
+++ b/tests/RunFormatter.spec.ts
@@ -58,8 +58,9 @@ describe("formatPace", () => {
         expect(formatPace(2.5)).toBe("6'40\" /km"); // 400 sec
     });
 
-    it('should return "測定なし" when averageSpeed is 0 or missing', () => {
+    it('should return "測定なし" when averageSpeed is <= 0 or missing', () => {
         expect(formatPace(0)).toBe("測定なし");
+        expect(formatPace(-1)).toBe("測定なし");
         expect(formatPace(undefined)).toBe("測定なし");
         expect(formatPace(null as any)).toBe("測定なし");
     });


### PR DESCRIPTION
🎯 **What:** Added a missing test case for `averageSpeed = -1` in `tests/RunFormatter.spec.ts`.
📊 **Coverage:** The tests now fully verify the condition `!averageSpeed || averageSpeed <= 0` in `formatPace` function.
✨ **Result:** Increased testing confidence, maintaining 100% test coverage for `formatPace` in `RunFormatter.ts`.

---
*PR created automatically by Jules for task [4831249686901310870](https://jules.google.com/task/4831249686901310870) started by @kurousa*