### PR TITLE
test: add unit tests for athlete.ts

### DIFF
--- a/athlete.ts
+++ b/athlete.ts
@@ -27,3 +27,11 @@ function __syncAthleteData(): void {
 
 }
 
+
+// Node.js環境（テスト時）のみエクスポートする
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        getAthleteWeight,
+        __syncAthleteData,
+    };
+}

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,5 +1,0 @@
-test: add unit tests for athlete.ts
-
-- Added conditional export block to `athlete.ts` to expose `getAthleteWeight` and `__syncAthleteData` for Vitest tests.
-- Created `tests/athlete.spec.ts` to cover different branches of athlete data sync and weight retrieval.
-- Verified passing tests.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,5 @@
+test: add unit tests for athlete.ts
+
+- Added conditional export block to `athlete.ts` to expose `getAthleteWeight` and `__syncAthleteData` for Vitest tests.
+- Created `tests/athlete.spec.ts` to cover different branches of athlete data sync and weight retrieval.
+- Verified passing tests.

--- a/tests/athlete.spec.ts
+++ b/tests/athlete.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getAthleteWeight, __syncAthleteData } from '../athlete';
 
 describe('athlete', () => {

--- a/tests/athlete.spec.ts
+++ b/tests/athlete.spec.ts
@@ -7,6 +7,10 @@ describe('athlete', () => {
         vi.stubGlobal('Logger', { log: vi.fn() });
     });
 
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
     describe('getAthleteWeight', () => {
         it('should return weight when profile and weight are present', () => {
             vi.stubGlobal('getStravaAthleteProfile', vi.fn(() => ({ weight: 65.5 })));

--- a/tests/athlete.spec.ts
+++ b/tests/athlete.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getAthleteWeight, __syncAthleteData } from '../athlete';
+
+describe('athlete', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubGlobal('Logger', { log: vi.fn() });
+    });
+
+    describe('getAthleteWeight', () => {
+        it('should return weight when profile and weight are present', () => {
+            vi.stubGlobal('getStravaAthleteProfile', vi.fn(() => ({ weight: 65.5 })));
+            const result = getAthleteWeight();
+            expect(result).toBe(65.5);
+        });
+
+        it('should return null when profile does not have weight', () => {
+            vi.stubGlobal('getStravaAthleteProfile', vi.fn(() => ({ weight: null })));
+            const result = getAthleteWeight();
+            expect(result).toBeNull();
+        });
+
+        it('should return null when profile is null', () => {
+            vi.stubGlobal('getStravaAthleteProfile', vi.fn(() => null));
+            const result = getAthleteWeight();
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('__syncAthleteData', () => {
+        it('should log athlete info including main bike name', () => {
+            const mockProfile = {
+                firstname: 'Taro',
+                lastname: 'Yamada',
+                weight: 65.5,
+                ftp: 250,
+                bikes: [
+                    { id: 'b1', primary: false, name: 'Bike 1' },
+                    { id: 'b2', primary: true, name: 'Main Bike' }
+                ]
+            };
+            vi.stubGlobal('getStravaAthleteProfile', vi.fn(() => mockProfile));
+
+            __syncAthleteData();
+
+            expect(global.Logger.log).toHaveBeenCalledWith('アスリート: Taro Yamada');
+            expect(global.Logger.log).toHaveBeenCalledWith('体重: 65.5kg, FTP: 250W, メインバイク: Main Bike');
+        });
+
+        it('should log "未設定" if no primary bike is found', () => {
+            const mockProfile = {
+                firstname: 'Taro',
+                lastname: 'Yamada',
+                weight: 65.5,
+                ftp: 250,
+                bikes: [
+                    { id: 'b1', primary: false, name: 'Bike 1' }
+                ]
+            };
+            vi.stubGlobal('getStravaAthleteProfile', vi.fn(() => mockProfile));
+
+            __syncAthleteData();
+
+            expect(global.Logger.log).toHaveBeenCalledWith('アスリート: Taro Yamada');
+            expect(global.Logger.log).toHaveBeenCalledWith('体重: 65.5kg, FTP: 250W, メインバイク: 未設定');
+        });
+
+        it('should log "未設定" if bikes array is empty', () => {
+            const mockProfile = {
+                firstname: 'Taro',
+                lastname: 'Yamada',
+                weight: 65.5,
+                ftp: 250,
+                bikes: []
+            };
+            vi.stubGlobal('getStravaAthleteProfile', vi.fn(() => mockProfile));
+
+            __syncAthleteData();
+
+            expect(global.Logger.log).toHaveBeenCalledWith('アスリート: Taro Yamada');
+            expect(global.Logger.log).toHaveBeenCalledWith('体重: 65.5kg, FTP: 250W, メインバイク: 未設定');
+        });
+
+        it('should do nothing if profile is null', () => {
+            vi.stubGlobal('getStravaAthleteProfile', vi.fn(() => null));
+
+            __syncAthleteData();
+
+            expect(global.Logger.log).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
- Added conditional export block to `athlete.ts` to expose `getAthleteWeight` and `__syncAthleteData` for Vitest tests without breaking the GAS global environment.
- Created `tests/athlete.spec.ts` to cover different branches of athlete data sync and weight retrieval.
- Mocked GAS globals (`Logger`) and internal functions (`getStravaAthleteProfile`) properly.
- All tests passing.

---
*PR created automatically by Jules for task [16443266030310443973](https://jules.google.com/task/16443266030310443973) started by @kurousa*