### PR TITLE
Fix ReferenceError and refactor configuration to global namespace

### DIFF
--- a/ai.ts
+++ b/ai.ts
@@ -12,12 +12,12 @@ let cachedAiApiKey: string | null = null;
  */
 function generateAiComment(activity: StravaActivity): string {
     if (cachedAiApiKey === null) {
-        cachedAiApiKey = PropertiesService.getScriptProperties().getProperty(PROP_GEMINI_API_KEY) || '';
+        cachedAiApiKey = PropertiesService.getScriptProperties().getProperty(Config.PROP_GEMINI_API_KEY) || '';
     }
     const apiKey = cachedAiApiKey;
 
     if (!apiKey) {
-        Logger.log(`${PROP_GEMINI_API_KEY} が設定されていないため、AIコメント生成をスキップします。`);
+        Logger.log(`${Config.PROP_GEMINI_API_KEY} が設定されていないため、AIコメント生成をスキップします。`);
         return '';
     }
 
@@ -42,7 +42,7 @@ function generateAiComment(activity: StravaActivity): string {
 - 余計な挨拶や解説は省き、コメント本体のみを出力してください。
 `.trim();
 
-    const url = `${GEMINI_API_BASE}?key=${apiKey}`;
+    const url = `${Config.GEMINI_API_BASE}?key=${apiKey}`;
 
     const payload = {
         contents: [{

--- a/api.ts
+++ b/api.ts
@@ -33,7 +33,7 @@ function getStravaActivities(afterDate?: Date, beforeDate?: Date, perPage: numbe
             .map(key => encodeURIComponent(key) + '=' + encodeURIComponent(String(currentParams[key])))
             .join('&');
 
-        const url = `${STRAVA_API_BASE}/athlete/activities?${queryString}`;
+        const url = `${Config.STRAVA_API_BASE}/athlete/activities?${queryString}`;
         Logger.log(`[API Request] URL: ${url}`);
 
         try {
@@ -69,7 +69,7 @@ function getStravaActivities(afterDate?: Date, beforeDate?: Date, perPage: numbe
             page++;
 
             // Strava APIのレート制限（連続アクセス制限）対策
-            Utilities.sleep(STRAVA_API_DELAY_MS);
+            Utilities.sleep(Config.STRAVA_API_DELAY_MS);
 
         } catch (e) {
             const errorMsg = 'Strava APIの呼び出しに失敗しました: ' + (e as Error).toString();
@@ -95,7 +95,7 @@ function getStravaAthleteProfile(): StravaAthlete | null {
         return null;
     }
 
-    const url = `${STRAVA_API_BASE}/athlete`;
+    const url = `${Config.STRAVA_API_BASE}/athlete`;
 
     try {
         const response = UrlFetchApp.fetch(url, {
@@ -134,7 +134,7 @@ function getStravaActivity(id: number): StravaActivity | null {
         return null;
     }
 
-    const url = `${STRAVA_API_BASE}/activities/${id}`;
+    const url = `${Config.STRAVA_API_BASE}/activities/${id}`;
 
     try {
         const response = UrlFetchApp.fetch(url, {
@@ -163,13 +163,13 @@ function getStravaActivity(id: number): StravaActivity | null {
  * Strava Webhook サブスクリプションを作成する
  */
 function createStravaWebhookSubscription(callbackUrl: string, verifyToken: string): StravaWebhookSubscription | null {
-    const url = `${STRAVA_API_BASE}/push_subscriptions`;
+    const url = `${Config.STRAVA_API_BASE}/push_subscriptions`;
     const scriptProps = PropertiesService.getScriptProperties();
-    const clientId = scriptProps.getProperty(PROP_STRAVA_CLIENT_ID);
-    const clientSecret = scriptProps.getProperty(PROP_STRAVA_CLIENT_SECRET);
+    const clientId = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_ID);
+    const clientSecret = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_SECRET);
 
     if (!clientId || !clientSecret) {
-        Logger.log("エラー: " + PROP_STRAVA_CLIENT_ID + " または " + PROP_STRAVA_CLIENT_SECRET + " が設定されていません。");
+        Logger.log("エラー: " + Config.PROP_STRAVA_CLIENT_ID + " または " + Config.PROP_STRAVA_CLIENT_SECRET + " が設定されていません。");
         return null;
     }
 
@@ -204,15 +204,15 @@ function createStravaWebhookSubscription(callbackUrl: string, verifyToken: strin
  */
 function viewStravaWebhookSubscriptions(): StravaWebhookSubscription[] {
     const scriptProps = PropertiesService.getScriptProperties();
-    const clientId = scriptProps.getProperty(PROP_STRAVA_CLIENT_ID);
-    const clientSecret = scriptProps.getProperty(PROP_STRAVA_CLIENT_SECRET);
+    const clientId = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_ID);
+    const clientSecret = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_SECRET);
 
     if (!clientId || !clientSecret) {
-        Logger.log(`エラー: ${PROP_STRAVA_CLIENT_ID} または ${PROP_STRAVA_CLIENT_SECRET} が設定されていません。`);
+        Logger.log(`エラー: ${Config.PROP_STRAVA_CLIENT_ID} または ${Config.PROP_STRAVA_CLIENT_SECRET} が設定されていません。`);
         return [];
     }
 
-    const url = `${STRAVA_API_BASE}/push_subscriptions?client_id=${clientId}&client_secret=${clientSecret}`;
+    const url = `${Config.STRAVA_API_BASE}/push_subscriptions?client_id=${clientId}&client_secret=${clientSecret}`;
 
     try {
         const response = UrlFetchApp.fetch(url, {
@@ -237,15 +237,15 @@ function viewStravaWebhookSubscriptions(): StravaWebhookSubscription[] {
  */
 function deleteStravaWebhookSubscription(id: number): boolean {
     const scriptProps = PropertiesService.getScriptProperties();
-    const clientId = scriptProps.getProperty(PROP_STRAVA_CLIENT_ID);
-    const clientSecret = scriptProps.getProperty(PROP_STRAVA_CLIENT_SECRET);
+    const clientId = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_ID);
+    const clientSecret = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_SECRET);
 
     if (!clientId || !clientSecret) {
-        Logger.log(`エラー: ${PROP_STRAVA_CLIENT_ID} または ${PROP_STRAVA_CLIENT_SECRET} が設定されていません。`);
+        Logger.log(`エラー: ${Config.PROP_STRAVA_CLIENT_ID} または ${Config.PROP_STRAVA_CLIENT_SECRET} が設定されていません。`);
         return false;
     }
 
-    const url = `${STRAVA_API_BASE}/push_subscriptions/${id}?client_id=${clientId}&client_secret=${clientSecret}`;
+    const url = `${Config.STRAVA_API_BASE}/push_subscriptions/${id}?client_id=${clientId}&client_secret=${clientSecret}`;
 
     try {
         const response = UrlFetchApp.fetch(url, {

--- a/auth.ts
+++ b/auth.ts
@@ -6,15 +6,24 @@
 // OAuth2ライブラリはGAS標準型定義に含まれないため、グローバル宣言を追加
 declare const OAuth2: any;
 
+let cachedStravaClientId: string | null = null;
+let cachedStravaClientSecret: string | null = null;
+let cachedStravaScope: string | null = null;
+
 /**
  * Strava連携のためのOAuth2サービスを取得する
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getOAuthService(): any {
-    const scriptProps = PropertiesService.getScriptProperties();
-    const CLIENT_ID = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_ID);
-    const CLIENT_SECRET = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_SECRET);
-    const STRAVA_SCOPE = scriptProps.getProperty(Config.PROP_STRAVA_SCOPE);
+    if (cachedStravaClientId === null) {
+        const scriptProps = PropertiesService.getScriptProperties();
+        cachedStravaClientId = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_ID) || '';
+        cachedStravaClientSecret = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_SECRET) || '';
+        cachedStravaScope = scriptProps.getProperty(Config.PROP_STRAVA_SCOPE) || '';
+    }
+    const CLIENT_ID = cachedStravaClientId;
+    const CLIENT_SECRET = cachedStravaClientSecret;
+    const STRAVA_SCOPE = cachedStravaScope;
 
     if (!CLIENT_ID || !CLIENT_SECRET) {
         throw new Error(`${Config.PROP_STRAVA_CLIENT_ID} または ${Config.PROP_STRAVA_CLIENT_SECRET} がスクリプトプロパティに設定されていません。`);

--- a/auth.ts
+++ b/auth.ts
@@ -6,18 +6,18 @@
 // OAuth2ライブラリはGAS標準型定義に含まれないため、グローバル宣言を追加
 declare const OAuth2: any;
 
-const scriptProps = PropertiesService.getScriptProperties();
-const CLIENT_ID = scriptProps.getProperty(PROP_STRAVA_CLIENT_ID);
-const CLIENT_SECRET = scriptProps.getProperty(PROP_STRAVA_CLIENT_SECRET);
-const STRAVA_SCOPE = scriptProps.getProperty(PROP_STRAVA_SCOPE);
-
 /**
  * Strava連携のためのOAuth2サービスを取得する
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getOAuthService(): any {
+    const scriptProps = PropertiesService.getScriptProperties();
+    const CLIENT_ID = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_ID);
+    const CLIENT_SECRET = scriptProps.getProperty(Config.PROP_STRAVA_CLIENT_SECRET);
+    const STRAVA_SCOPE = scriptProps.getProperty(Config.PROP_STRAVA_SCOPE);
+
     if (!CLIENT_ID || !CLIENT_SECRET) {
-        throw new Error(`${PROP_STRAVA_CLIENT_ID} または ${PROP_STRAVA_CLIENT_SECRET} がスクリプトプロパティに設定されていません。`);
+        throw new Error(`${Config.PROP_STRAVA_CLIENT_ID} または ${Config.PROP_STRAVA_CLIENT_SECRET} がスクリプトプロパティに設定されていません。`);
     }
     return OAuth2.createService('Strava')
         .setAuthorizationBaseUrl('https://www.strava.com/oauth/authorize')

--- a/const.ts
+++ b/const.ts
@@ -76,6 +76,7 @@ deepFreeze(Config);
 // Node.js環境（テスト時）でのグローバル化
 if (typeof global !== 'undefined') {
     (global as any).Config = Config;
+    (global as any).deepFreeze = deepFreeze;
     // 既存のコード（テスト等）との互換性のため、個別の定数もグローバルに展開する
     Object.assign(global, Config);
 }
@@ -84,6 +85,7 @@ if (typeof global !== 'undefined') {
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         Config,
+        deepFreeze,
         ...Config
     };
 }

--- a/const.ts
+++ b/const.ts
@@ -1,108 +1,89 @@
+"use strict";
+
 // ==========================================
 // 定数定義 (const.ts)
 // ==========================================
 
-// プロパティキー
-const PROP_CALENDAR_ID = 'CALENDAR_ID';
-const PROP_STRAVA_CLIENT_ID = 'STRAVA_CLIENT_ID';
-const PROP_STRAVA_CLIENT_SECRET = 'STRAVA_CLIENT_SECRET';
-const PROP_STRAVA_SCOPE = 'STRAVA_SCOPE';
-const PROP_STRAVA_VERIFY_TOKEN = 'STRAVA_WEBHOOK_VERIFY_TOKEN';
-const PROP_WEB_APP_URL = 'WEB_APP_URL';
-const PROP_SPREADSHEET_ID = 'SPREADSHEET_ID';
-const PROP_DISCORD_WEBHOOK_URL = 'DISCORD_WEBHOOK_URL';
-const PROP_GEMINI_API_KEY = 'GEMINI_API_KEY';
-const PROP_LAST_ERROR_NOTIFIED_AT = 'LAST_ERROR_NOTIFIED_AT';
+/**
+ * Object.freeze をネストされたオブジェクトにも適用するヘルパー関数
+ */
+function deepFreeze<T extends Record<string, any>>(object: T): Readonly<T> {
+    const propNames = Object.getOwnPropertyNames(object);
+    for (const name of propNames) {
+        const value = object[name];
+        if (value && typeof value === 'object') {
+            deepFreeze(value as Record<string, any>);
+        }
+    }
+    return Object.freeze(object);
+}
 
-// API エンドポイント
-const STRAVA_API_BASE = 'https://www.strava.com/api/v3';
-const OPEN_METEO_API_BASE = 'https://api.open-meteo.com/v1/forecast';
-const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
+// 1つの var オブジェクトとして定義する（GASのグローバルスコープ共有のため）
+var Config = {
+    // プロパティキー
+    PROP_CALENDAR_ID: 'CALENDAR_ID',
+    PROP_STRAVA_CLIENT_ID: 'STRAVA_CLIENT_ID',
+    PROP_STRAVA_CLIENT_SECRET: 'STRAVA_CLIENT_SECRET',
+    PROP_STRAVA_SCOPE: 'STRAVA_SCOPE',
+    PROP_STRAVA_VERIFY_TOKEN: 'STRAVA_WEBHOOK_VERIFY_TOKEN',
+    PROP_WEB_APP_URL: 'WEB_APP_URL',
+    PROP_SPREADSHEET_ID: 'SPREADSHEET_ID',
+    PROP_DISCORD_WEBHOOK_URL: 'DISCORD_WEBHOOK_URL',
+    PROP_GEMINI_API_KEY: 'GEMINI_API_KEY',
+    PROP_LAST_ERROR_NOTIFIED_AT: 'LAST_ERROR_NOTIFIED_AT',
 
-// 設定定数
-const CALENDAR_API_DELAY_MS = 200;
-const STRAVA_API_DELAY_MS = 200;
-const STRAVA_ACTIVITY_ID_REGEX = /strava\.com\/activities\/(\d+)/i;
+    // API エンドポイント
+    STRAVA_API_BASE: 'https://www.strava.com/api/v3',
+    OPEN_METEO_API_BASE: 'https://api.open-meteo.com/v1/forecast',
+    GEMINI_API_BASE: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent',
 
-const DISTANCE_ACTIVITIES = new Set([
-    'Run', 'Ride', 'Walk', 'Hike', 'Swim', 'AlpineSki', 'BackcountrySki', 'NordicSki', 'RollerSki',
-    'Canoeing', 'Kayaking', 'Rowing', 'StandUpPaddling', 'Surfing', 'Sail', 'Windsurf', 'IceSkate',
-    'InlineSkate', 'Skateboard', 'Snowshoe', 'Kitesurf', 'VirtualRide', 'VirtualRun', 'GravelRide',
-    'MountainBikeRide', 'EMountainBikeRide', 'Velomobile', 'Handcycle', 'Wheelchair'
-]);
+    // 設定定数
+    CALENDAR_API_DELAY_MS: 200,
+    STRAVA_API_DELAY_MS: 200,
+    STRAVA_ACTIVITY_ID_REGEX: /strava\.com\/activities\/(\d+)/i,
 
-const MAP_FOLDER_NAME = 'Strava_Route_Maps';
-const GEAR_CONFIG_PREFIX = 'GEAR_CONFIG_';
-const BACKUP_SHEET_NAME = 'Activities';
+    DISTANCE_ACTIVITIES: new Set([
+        'Run', 'Ride', 'Walk', 'Hike', 'Swim', 'AlpineSki', 'BackcountrySki', 'NordicSki', 'RollerSki',
+        'Canoeing', 'Kayaking', 'Rowing', 'StandUpPaddling', 'Surfing', 'Sail', 'Windsurf', 'IceSkate',
+        'InlineSkate', 'Skateboard', 'Snowshoe', 'Kitesurf', 'VirtualRide', 'VirtualRun', 'GravelRide',
+        'MountainBikeRide', 'EMountainBikeRide', 'Velomobile', 'Handcycle', 'Wheelchair'
+    ]),
 
-// アクティビティごとのスタイルデータ (EventColor は lazy init で解決)
-const ACTIVITY_STYLE_DATA = {
-    'Walk': { emoji: '🚶', colorName: 'GREEN' },
-    'Run': { emoji: '🏃', colorName: 'BLUE' },
-    'VirtualRun': { emoji: '🏃', colorName: 'BLUE' },
-    'Ride': { emoji: '🚴', colorName: 'RED' },
-    'VirtualRide': { emoji: '🚴', colorName: 'RED' },
-    'Swim': { emoji: '🏊', colorName: 'CYAN' },
-    'Hike': { emoji: '🥾', colorName: 'PALE_GREEN' },
-    'Workout': { emoji: '🏋️', colorName: 'ORANGE' },
-    'WeightTraining': { emoji: '🏋️', colorName: 'ORANGE' },
-    'Yoga': { emoji: '🧘', colorName: 'GREEN' },
+    MAP_FOLDER_NAME: 'Strava_Route_Maps',
+    GEAR_CONFIG_PREFIX: 'GEAR_CONFIG_',
+    BACKUP_SHEET_NAME: 'Activities',
+
+    // アクティビティごとのスタイルデータ
+    ACTIVITY_STYLE_DATA: {
+        'Walk': { emoji: '🚶', colorName: 'GREEN' },
+        'Run': { emoji: '🏃', colorName: 'BLUE' },
+        'VirtualRun': { emoji: '🏃', colorName: 'BLUE' },
+        'Ride': { emoji: '🚴', colorName: 'RED' },
+        'VirtualRide': { emoji: '🚴', colorName: 'RED' },
+        'Swim': { emoji: '🏊', colorName: 'CYAN' },
+        'Hike': { emoji: '🥾', colorName: 'PALE_GREEN' },
+        'Workout': { emoji: '🏋️', colorName: 'ORANGE' },
+        'WeightTraining': { emoji: '🏋️', colorName: 'ORANGE' },
+        'Yoga': { emoji: '🧘', colorName: 'GREEN' },
+    },
+
+    DEFAULT_ACTIVITY_STYLE_DATA: { emoji: '🏅', colorName: 'GRAY' }
 };
 
-const DEFAULT_ACTIVITY_STYLE_DATA = { emoji: '🏅', colorName: 'GRAY' };
+// オブジェクトを凍結して変更不可にする
+deepFreeze(Config);
 
 // Node.js環境（テスト時）でのグローバル化
 if (typeof global !== 'undefined') {
-    Object.assign(global, {
-        PROP_CALENDAR_ID,
-        PROP_STRAVA_CLIENT_ID,
-        PROP_STRAVA_CLIENT_SECRET,
-        PROP_STRAVA_SCOPE,
-        PROP_STRAVA_VERIFY_TOKEN,
-        PROP_WEB_APP_URL,
-        PROP_SPREADSHEET_ID,
-        PROP_DISCORD_WEBHOOK_URL,
-        PROP_GEMINI_API_KEY,
-        PROP_LAST_ERROR_NOTIFIED_AT,
-        STRAVA_API_BASE,
-        OPEN_METEO_API_BASE,
-        GEMINI_API_BASE,
-        CALENDAR_API_DELAY_MS,
-        STRAVA_API_DELAY_MS,
-        STRAVA_ACTIVITY_ID_REGEX,
-        DISTANCE_ACTIVITIES,
-        MAP_FOLDER_NAME,
-        GEAR_CONFIG_PREFIX,
-        BACKUP_SHEET_NAME,
-        ACTIVITY_STYLE_DATA,
-        DEFAULT_ACTIVITY_STYLE_DATA
-    });
+    (global as any).Config = Config;
+    // 既存のコード（テスト等）との互換性のため、個別の定数もグローバルに展開する
+    Object.assign(global, Config);
 }
 
 // Node.js環境（テスト時）のみエクスポートする
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
-        PROP_CALENDAR_ID,
-        PROP_STRAVA_CLIENT_ID,
-        PROP_STRAVA_CLIENT_SECRET,
-        PROP_STRAVA_SCOPE,
-        PROP_STRAVA_VERIFY_TOKEN,
-        PROP_WEB_APP_URL,
-        PROP_SPREADSHEET_ID,
-        PROP_DISCORD_WEBHOOK_URL,
-        PROP_GEMINI_API_KEY,
-        PROP_LAST_ERROR_NOTIFIED_AT,
-        STRAVA_API_BASE,
-        OPEN_METEO_API_BASE,
-        GEMINI_API_BASE,
-        CALENDAR_API_DELAY_MS,
-        STRAVA_API_DELAY_MS,
-        STRAVA_ACTIVITY_ID_REGEX,
-        DISTANCE_ACTIVITIES,
-        MAP_FOLDER_NAME,
-        GEAR_CONFIG_PREFIX,
-        BACKUP_SHEET_NAME,
-        ACTIVITY_STYLE_DATA,
-        DEFAULT_ACTIVITY_STYLE_DATA
+        Config,
+        ...Config
     };
 }

--- a/const.ts
+++ b/const.ts
@@ -42,12 +42,12 @@ var Config = {
     STRAVA_API_DELAY_MS: 200,
     STRAVA_ACTIVITY_ID_REGEX: /strava\.com\/activities\/(\d+)/i,
 
-    DISTANCE_ACTIVITIES: new Set([
+    DISTANCE_ACTIVITIES: [
         'Run', 'Ride', 'Walk', 'Hike', 'Swim', 'AlpineSki', 'BackcountrySki', 'NordicSki', 'RollerSki',
         'Canoeing', 'Kayaking', 'Rowing', 'StandUpPaddling', 'Surfing', 'Sail', 'Windsurf', 'IceSkate',
         'InlineSkate', 'Skateboard', 'Snowshoe', 'Kitesurf', 'VirtualRide', 'VirtualRun', 'GravelRide',
         'MountainBikeRide', 'EMountainBikeRide', 'Velomobile', 'Handcycle', 'Wheelchair'
-    ]),
+    ],
 
     MAP_FOLDER_NAME: 'Strava_Route_Maps',
     GEAR_CONFIG_PREFIX: 'GEAR_CONFIG_',

--- a/formatters/DefaultFormatter.ts
+++ b/formatters/DefaultFormatter.ts
@@ -87,7 +87,7 @@ let DEFAULT_ACTIVITY_STYLE_CACHE: Readonly<ActivityStyle> | null = null;
 
 function initStyles(): void {
     const styles: Record<string, ActivityStyle> = {};
-    for (const [key, value] of Object.entries(ACTIVITY_STYLE_DATA)) {
+    for (const [key, value] of Object.entries(Config.ACTIVITY_STYLE_DATA)) {
         styles[key] = {
             emoji: value.emoji,
             color: (CalendarApp.EventColor as any)[value.colorName]
@@ -96,8 +96,8 @@ function initStyles(): void {
     ACTIVITY_STYLES_CACHE = deepFreeze(styles);
 
     DEFAULT_ACTIVITY_STYLE_CACHE = Object.freeze({
-        emoji: DEFAULT_ACTIVITY_STYLE_DATA.emoji,
-        color: (CalendarApp.EventColor as any)[DEFAULT_ACTIVITY_STYLE_DATA.colorName]
+        emoji: Config.DEFAULT_ACTIVITY_STYLE_DATA.emoji,
+        color: (CalendarApp.EventColor as any)[Config.DEFAULT_ACTIVITY_STYLE_DATA.colorName]
     });
 }
 

--- a/formatters/DefaultFormatter.ts
+++ b/formatters/DefaultFormatter.ts
@@ -65,19 +65,6 @@ function makeDefaultDescription(activity: StravaActivity): string {
     return descriptionLines.join('\n').trim();
 }
 
-/**
- * Object.freeze をネストされたオブジェクトにも適用するヘルパー関数
- */
-function deepFreeze<T extends Record<string, unknown>>(object: T): Readonly<T> {
-    const propNames = Object.getOwnPropertyNames(object);
-    for (const name of propNames) {
-        const value = object[name];
-        if (value && typeof value === 'object') {
-            deepFreeze(value as Record<string, unknown>);
-        }
-    }
-    return Object.freeze(object);
-}
 
 // アクティビティごとの絵文字と色の定義
 // CalendarApp.EventColor への参照は、Node.js環境での ReferenceError 回避のため
@@ -130,7 +117,6 @@ function makeDescription(activity: StravaActivity): string {
 // Node.js環境（テスト時）のみエクスポートする
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
-        deepFreeze,
         initStyles,
         get ACTIVITY_STYLES_CACHE() { return ACTIVITY_STYLES_CACHE; },
         get DEFAULT_ACTIVITY_STYLE_CACHE() { return DEFAULT_ACTIVITY_STYLE_CACHE; },

--- a/gear.ts
+++ b/gear.ts
@@ -22,7 +22,7 @@ function checkGearAlerts(): void {
     const allProps = props.getProperties();
 
     gears.forEach(gear => {
-        const configStr = allProps[GEAR_CONFIG_PREFIX + gear.id];
+        const configStr = allProps[Config.GEAR_CONFIG_PREFIX + gear.id];
         if (!configStr) return;
 
         let config: GearConfig;
@@ -58,7 +58,7 @@ function checkGearAlerts(): void {
 
             // アラート済み距離を更新
             config.lastAlertedKm = currentKm;
-            props.setProperty(GEAR_CONFIG_PREFIX + gear.id, JSON.stringify(config));
+            props.setProperty(Config.GEAR_CONFIG_PREFIX + gear.id, JSON.stringify(config));
         }
     });
 }
@@ -89,7 +89,7 @@ function listGears(): void {
  */
 function setGearThreshold(gearId: string, thresholdKm: number, isPeriodic: boolean = false): void {
     const props = PropertiesService.getScriptProperties();
-    const currentConfigStr = props.getProperty(GEAR_CONFIG_PREFIX + gearId);
+    const currentConfigStr = props.getProperty(Config.GEAR_CONFIG_PREFIX + gearId);
 
     let lastAlertedKm = 0;
     if (currentConfigStr) {
@@ -107,7 +107,7 @@ function setGearThreshold(gearId: string, thresholdKm: number, isPeriodic: boole
         lastAlertedKm: lastAlertedKm
     };
 
-    props.setProperty(GEAR_CONFIG_PREFIX + gearId, JSON.stringify(config));
+    props.setProperty(Config.GEAR_CONFIG_PREFIX + gearId, JSON.stringify(config));
     Logger.log(`機材ID: ${gearId} にしきい値 ${thresholdKm}km (${isPeriodic ? '定期' : '1回限り'}) を設定しました。`);
 }
 

--- a/main.ts
+++ b/main.ts
@@ -118,9 +118,10 @@ function sendErrorEmail(message: string): void {
 function processActivityToCalendar(
     activity: StravaActivity,
     calendar: GoogleAppsScript.Calendar.Calendar,
-    distanceActivities: Set<string> = Config.DISTANCE_ACTIVITIES,
+    distanceActivitiesArg?: Set<string>,
     skipDuplicateCheck: boolean = false
 ): string | undefined {
+    const distanceActivities = distanceActivitiesArg || new Set(Config.DISTANCE_ACTIVITIES);
     // 時間の計算（Stravaは世界標準時なので、日本時間に合わせる必要があります）
     const startTime = new Date(activity.start_date);
     const endTime = new Date(startTime.getTime() + (activity.elapsed_time * 1000));
@@ -259,7 +260,7 @@ if (typeof module !== 'undefined' && module.exports) {
         getTargetCalendar,
         processActivityToCalendar,
         getExistingActivityIds,
-        DISTANCE_ACTIVITIES: Config.DISTANCE_ACTIVITIES,
+        DISTANCE_ACTIVITIES: new Set(Config.DISTANCE_ACTIVITIES),
         CALENDAR_API_DELAY_MS: Config.CALENDAR_API_DELAY_MS,
         STRAVA_ACTIVITY_ID_REGEX: Config.STRAVA_ACTIVITY_ID_REGEX,
     };

--- a/main.ts
+++ b/main.ts
@@ -4,8 +4,6 @@
 // カレンダーへの書き込みといった「このアプリのメインのお仕事」だけを残します。
 // ==========================================
 
-const CALENDAR_ID = PropertiesService.getScriptProperties().getProperty(PROP_CALENDAR_ID);
-
 /**
  * Retrieves a set of Strava activity IDs that are already present in the given calendar
  * within the specified date range.
@@ -16,7 +14,7 @@ function getExistingActivityIds(calendar: GoogleAppsScript.Calendar.Calendar, st
     existingEvents.forEach(event => {
         const desc = event.getDescription();
         if (desc) {
-            const match = desc.match(STRAVA_ACTIVITY_ID_REGEX);
+            const match = desc.match(Config.STRAVA_ACTIVITY_ID_REGEX);
             if (match && match[1]) {
                 existingActivityIds.add(match[1]);
             }
@@ -100,7 +98,7 @@ function sendErrorEmail(message: string): void {
     }
 
     const props = PropertiesService.getUserProperties();
-    const lastNotified = props.getProperty(PROP_LAST_ERROR_NOTIFIED_AT);
+    const lastNotified = props.getProperty(Config.PROP_LAST_ERROR_NOTIFIED_AT);
     const now = new Date().getTime();
     if (lastNotified && now - parseInt(lastNotified) < 24 * 60 * 60 * 1000) {
         return;
@@ -110,7 +108,7 @@ function sendErrorEmail(message: string): void {
     const body = 'Stravaとの連携でエラーが発生しました。\n\nエラー内容:\n' + message;
 
     MailApp.sendEmail(email, subject, body);
-    props.setProperty(PROP_LAST_ERROR_NOTIFIED_AT, now.toString());
+    props.setProperty(Config.PROP_LAST_ERROR_NOTIFIED_AT, now.toString());
     Logger.log('エラーメールを送信しました: ' + email);
 }
 
@@ -120,7 +118,7 @@ function sendErrorEmail(message: string): void {
 function processActivityToCalendar(
     activity: StravaActivity,
     calendar: GoogleAppsScript.Calendar.Calendar,
-    distanceActivities: Set<string> = DISTANCE_ACTIVITIES,
+    distanceActivities: Set<string> = Config.DISTANCE_ACTIVITIES,
     skipDuplicateCheck: boolean = false
 ): string | undefined {
     // 時間の計算（Stravaは世界標準時なので、日本時間に合わせる必要があります）
@@ -232,7 +230,7 @@ function processActivityToCalendar(
 
     // カレンダーAPIの連続作成制限を回避しつつ、GASの実行時間制限(6分)に配慮
     // 重複スキップ時は待機せず、カレンダーへの新規書き込みが行われた直後のみ短時間待機する
-    Utilities.sleep(CALENDAR_API_DELAY_MS);
+    Utilities.sleep(Config.CALENDAR_API_DELAY_MS);
 
     Logger.log(`カレンダーに登録しました: ID ${activity.id}`);
     return 'success';
@@ -242,8 +240,9 @@ function processActivityToCalendar(
 // カレンダー取得ユーティリティ
 // ==========================================
 function getTargetCalendar(): GoogleAppsScript.Calendar.Calendar | null {
-    if (CALENDAR_ID) {
-        const calendar = CalendarApp.getCalendarById(CALENDAR_ID);
+    const calendarId = PropertiesService.getScriptProperties().getProperty(Config.PROP_CALENDAR_ID);
+    if (calendarId) {
+        const calendar = CalendarApp.getCalendarById(calendarId);
         if (!calendar) {
             Logger.log('エラー: 指定されたカレンダーが見つかりません。');
         }

--- a/main.ts
+++ b/main.ts
@@ -259,8 +259,8 @@ if (typeof module !== 'undefined' && module.exports) {
         getTargetCalendar,
         processActivityToCalendar,
         getExistingActivityIds,
-        DISTANCE_ACTIVITIES,
-        CALENDAR_API_DELAY_MS,
-        STRAVA_ACTIVITY_ID_REGEX,
+        DISTANCE_ACTIVITIES: Config.DISTANCE_ACTIVITIES,
+        CALENDAR_API_DELAY_MS: Config.CALENDAR_API_DELAY_MS,
+        STRAVA_ACTIVITY_ID_REGEX: Config.STRAVA_ACTIVITY_ID_REGEX,
     };
 }

--- a/maps.ts
+++ b/maps.ts
@@ -2,11 +2,11 @@
  * マップ画像を保存するフォルダを取得または作成する
  */
 function getOrCreateMapFolder(): GoogleAppsScript.Drive.Folder {
-    const folders = DriveApp.getFoldersByName(MAP_FOLDER_NAME);
+    const folders = DriveApp.getFoldersByName(Config.MAP_FOLDER_NAME);
     if (folders.hasNext()) {
         return folders.next();
     }
-    return DriveApp.createFolder(MAP_FOLDER_NAME);
+    return DriveApp.createFolder(Config.MAP_FOLDER_NAME);
 }
 
 /**

--- a/notifier.ts
+++ b/notifier.ts
@@ -10,11 +10,11 @@ let DISCORD_WEBHOOK_URL_CACHE: string | null = null;
  */
 function sendSyncNotification(successCount: number, skipCount: number, isManual: boolean = false): void {
     if (DISCORD_WEBHOOK_URL_CACHE === null) {
-        DISCORD_WEBHOOK_URL_CACHE = PropertiesService.getScriptProperties().getProperty(PROP_DISCORD_WEBHOOK_URL) || '';
+        DISCORD_WEBHOOK_URL_CACHE = PropertiesService.getScriptProperties().getProperty(Config.PROP_DISCORD_WEBHOOK_URL) || '';
     }
 
     if (!DISCORD_WEBHOOK_URL_CACHE) {
-        Logger.log(`${PROP_DISCORD_WEBHOOK_URL} が設定されていないため、通知をスキップします。`);
+        Logger.log(`${Config.PROP_DISCORD_WEBHOOK_URL} が設定されていないため、通知をスキップします。`);
         return;
     }
 
@@ -55,11 +55,11 @@ function sendSyncNotification(successCount: number, skipCount: number, isManual:
  */
 function sendGearAlert(gearName: string, currentDistanceKm: number, thresholdKm: number, isPeriodic: boolean): void {
     if (DISCORD_WEBHOOK_URL_CACHE === null) {
-        DISCORD_WEBHOOK_URL_CACHE = PropertiesService.getScriptProperties().getProperty(PROP_DISCORD_WEBHOOK_URL) || '';
+        DISCORD_WEBHOOK_URL_CACHE = PropertiesService.getScriptProperties().getProperty(Config.PROP_DISCORD_WEBHOOK_URL) || '';
     }
 
     if (!DISCORD_WEBHOOK_URL_CACHE) {
-        Logger.log(`${PROP_DISCORD_WEBHOOK_URL} が設定されていないため、機材アラートをスキップします。`);
+        Logger.log(`${Config.PROP_DISCORD_WEBHOOK_URL} が設定されていないため、機材アラートをスキップします。`);
         return;
     }
 

--- a/router.ts
+++ b/router.ts
@@ -11,9 +11,9 @@
 function doGet(e: any): GoogleAppsScript.HTML.HtmlOutput | GoogleAppsScript.Content.TextOutput {
     // Strava Webhook のバリデーションリクエスト (GET) の場合
     if (e && e.parameter && e.parameter['hub.mode'] === 'subscribe') {
-        const verifyToken = PropertiesService.getScriptProperties().getProperty(PROP_STRAVA_VERIFY_TOKEN);
+        const verifyToken = PropertiesService.getScriptProperties().getProperty(Config.PROP_STRAVA_VERIFY_TOKEN);
         if (!verifyToken) {
-            Logger.log(`エラー: ${PROP_STRAVA_VERIFY_TOKEN} が設定されていません。`);
+            Logger.log(`エラー: ${Config.PROP_STRAVA_VERIFY_TOKEN} が設定されていません。`);
             return HtmlService.createHtmlOutput('Internal Server Error: Missing Verify Token');
         }
 

--- a/sheets.ts
+++ b/sheets.ts
@@ -2,25 +2,24 @@
 // スプレッドシートへのバックアップ処理 (sheets.ts)
 // ==========================================
 
-const SPREADSHEET_ID = PropertiesService.getScriptProperties().getProperty(PROP_SPREADSHEET_ID);
-
 /**
  * 成功したアクティビティを一括でスプレッドシートに追記する
  */
 function backupToSpreadsheet(activities: StravaActivity[]): void {
-    if (!SPREADSHEET_ID) {
-        Logger.log(`${PROP_SPREADSHEET_ID} が設定されていないため、バックアップをスキップします。`);
+    const spreadsheetId = PropertiesService.getScriptProperties().getProperty(Config.PROP_SPREADSHEET_ID);
+    if (!spreadsheetId) {
+        Logger.log(`${Config.PROP_SPREADSHEET_ID} が設定されていないため、バックアップをスキップします。`);
         return;
     }
     if (activities.length === 0) return;
 
     try {
-        const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
-        let sheet = ss.getSheetByName(BACKUP_SHEET_NAME);
+        const ss = SpreadsheetApp.openById(spreadsheetId);
+        let sheet = ss.getSheetByName(Config.BACKUP_SHEET_NAME);
         
         // シートが存在しない場合は新規作成し、ヘッダーを設定
         if (!sheet) {
-            sheet = ss.insertSheet(BACKUP_SHEET_NAME);
+            sheet = ss.insertSheet(Config.BACKUP_SHEET_NAME);
             const headers = ['ID', '日付', '種類', '名前', '距離 (km)', '時間 (分)', '獲得標高 (m)', '平均心拍数', '体重(kg)', 'URL'];
             sheet.appendRow(headers);
             // ヘッダー行を固定し、太字にする装飾

--- a/tests/DefaultFormatter.spec.ts
+++ b/tests/DefaultFormatter.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { deepFreeze, getCommonMetrics, makeDefaultDescription, getActivityStyle, makeDescription } from '../formatters/DefaultFormatter';
+import { getCommonMetrics, makeDefaultDescription, getActivityStyle, makeDescription } from '../formatters/DefaultFormatter';
 
 // Mock Google Apps Script global CalendarApp
 global.CalendarApp = {

--- a/weather.ts
+++ b/weather.ts
@@ -25,7 +25,7 @@ function fetchWeatherData(lat: number, lng: number, dateObj: Date): string {
     // hourly=temperature_2m,weathercode,windspeed_10m で気温、天気コード、風速を取得
     // timezone=Asia%2FTokyo で東京のタイムゾーンを指定
     // windspeed_unit=kmh で風速をkm/h単位で取得
-    const url = `${OPEN_METEO_API_BASE}?latitude=${lat}&longitude=${lng}&start_date=${dateString}&end_date=${dateString}&hourly=temperature_2m,weathercode,windspeed_10m&timezone=Asia%2FTokyo&windspeed_unit=kmh`;
+    const url = `${Config.OPEN_METEO_API_BASE}?latitude=${lat}&longitude=${lng}&start_date=${dateString}&end_date=${dateString}&hourly=temperature_2m,weathercode,windspeed_10m&timezone=Asia%2FTokyo&windspeed_unit=kmh`;
 
     try {
         const response = UrlFetchApp.fetch(url, { muteHttpExceptions: true });

--- a/webhook.ts
+++ b/webhook.ts
@@ -28,16 +28,16 @@ function handleStravaWebhook(event: StravaWebhookEvent): void {
  */
 function registerStravaWebhook(): void {
     const scriptProps = PropertiesService.getScriptProperties();
-    const webAppUrl = scriptProps.getProperty(PROP_WEB_APP_URL);
-    const verifyToken = scriptProps.getProperty(PROP_STRAVA_VERIFY_TOKEN);
+    const webAppUrl = scriptProps.getProperty(Config.PROP_WEB_APP_URL);
+    const verifyToken = scriptProps.getProperty(Config.PROP_STRAVA_VERIFY_TOKEN);
 
     if (!verifyToken) {
-        Logger.log(`エラー: ${PROP_STRAVA_VERIFY_TOKEN} が設定されていません。`);
+        Logger.log(`エラー: ${Config.PROP_STRAVA_VERIFY_TOKEN} が設定されていません。`);
         return;
     }
 
     if (!webAppUrl) {
-        Logger.log(`エラー: ${PROP_WEB_APP_URL} が設定されていません。WebアプリとしてデプロイしたURLを設定してください。`);
+        Logger.log(`エラー: ${Config.PROP_WEB_APP_URL} が設定されていません。WebアプリとしてデプロイしたURLを設定してください。`);
         return;
     }
 


### PR DESCRIPTION
This change addresses a common `ReferenceError` in Google Apps Script's V8 engine where `const` declarations are not reliably shared across multiple files or are subject to Temporal Dead Zone (TDZ) issues depending on file load order.

By using a single `var Config` object, we ensure that all constants are immediately available in the global scope of all script files. Additionally, moving property lookups into functions reduces the overhead during initial script execution and prevents potential errors if properties are accessed before the script is fully initialized.

Fixes #110

---
*PR created automatically by Jules for task [5158157865889339808](https://jules.google.com/task/5158157865889339808) started by @kurousa*