### PR TITLE
🧹 [Code Health] Replace `any` types with specific GAS Web App event types in router

### DIFF
--- a/router.ts
+++ b/router.ts
@@ -8,7 +8,7 @@
  * - Strava Webhook のバリデーションリクエスト (GET) に対応する
  * - 通常のアクセス（インポート画面）を表示する
  */
-function doGet(e: any): GoogleAppsScript.HTML.HtmlOutput | GoogleAppsScript.Content.TextOutput {
+function doGet(e: GoogleAppsScript.Events.DoGet): GoogleAppsScript.HTML.HtmlOutput | GoogleAppsScript.Content.TextOutput {
     // Strava Webhook のバリデーションリクエスト (GET) の場合
     if (e && e.parameter && e.parameter['hub.mode'] === 'subscribe') {
         const verifyToken = PropertiesService.getScriptProperties().getProperty(Config.PROP_STRAVA_VERIFY_TOKEN);
@@ -67,7 +67,7 @@ function doGet(e: any): GoogleAppsScript.HTML.HtmlOutput | GoogleAppsScript.Cont
  * POSTリクエストハンドラー
  * - Strava Webhook からの通知 (POST) を受け取る
  */
-function doPost(e: any): GoogleAppsScript.Content.TextOutput {
+function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.TextOutput {
     try {
         const event: StravaWebhookEvent = JSON.parse(e.postData.contents);
         Logger.log(`[Webhook] Received event: ${event.aspect_type} for ${event.object_type} (ID: ${event.object_id})`);


### PR DESCRIPTION
🎯 **What:** Replaced the `any` type parameters in `doGet` and `doPost` functions within `router.ts` with their corresponding strongly typed definitions from `@types/google-apps-script` (`GoogleAppsScript.Events.DoGet` and `GoogleAppsScript.Events.DoPost`).
💡 **Why:** Using `any` bypasses TypeScript's type checking, hiding potential errors and reducing code readability. Leveraging the official types provides clear documentation about expected event payload structures (like `e.parameter` or `e.postData.contents`) directly inside the editor and ensures safer and more robust event handling logic.
✅ **Verification:** Verified the code compiles successfully by running `pnpm run typecheck` and ensured all tests, specifically `tests/router.spec.ts`, pass without issues via `pnpm test`.
✨ **Result:** Improved type safety and maintainability in the routing file without altering the core logic.

---
*PR created automatically by Jules for task [3506088853432543557](https://jules.google.com/task/3506088853432543557) started by @kurousa*