### PR TITLE
🧹 fix: Type event parameters in doGet and doPost

### DIFF
--- a/router.ts
+++ b/router.ts
@@ -8,7 +8,7 @@
  * - Strava Webhook のバリデーションリクエスト (GET) に対応する
  * - 通常のアクセス（インポート画面）を表示する
  */
-function doGet(e: any): GoogleAppsScript.HTML.HtmlOutput | GoogleAppsScript.Content.TextOutput {
+function doGet(e: GoogleAppsScript.Events.DoGet): GoogleAppsScript.HTML.HtmlOutput | GoogleAppsScript.Content.TextOutput {
     // Strava Webhook のバリデーションリクエスト (GET) の場合
     if (e && e.parameter && e.parameter['hub.mode'] === 'subscribe') {
         const verifyToken = PropertiesService.getScriptProperties().getProperty(Config.PROP_STRAVA_VERIFY_TOKEN);
@@ -67,7 +67,7 @@ function doGet(e: any): GoogleAppsScript.HTML.HtmlOutput | GoogleAppsScript.Cont
  * POSTリクエストハンドラー
  * - Strava Webhook からの通知 (POST) を受け取る
  */
-function doPost(e: any): GoogleAppsScript.Content.TextOutput {
+function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.TextOutput {
     try {
         const event: StravaWebhookEvent = JSON.parse(e.postData.contents);
         Logger.log(`[Webhook] Received event: ${event.aspect_type} for ${event.object_type} (ID: ${event.object_id})`);


### PR DESCRIPTION
🎯 **What:** Replaced the generic `any` type with `GoogleAppsScript.Events.DoGet` and `GoogleAppsScript.Events.DoPost` in `router.ts` for the `doGet` and `doPost` functions, respectively.

💡 **Why:** This leverages the `@types/google-apps-script` package to provide better type safety, autocomplete, and maintainability. Using `any` bypasses type checking, whereas specific types ensure that properties accessed on the event object (`e`) are valid according to the Google Apps Script API. This is a pure refactoring that improves code health without changing functional behavior.

✅ **Verification:**
1. Ran `pnpm run typecheck` and observed no TypeScript errors.
2. Ran `pnpm test` and all 180 tests across 22 test suites passed successfully.
3. The changes preserve existing logic and solely address the typing of the function signatures.

✨ **Result:** The `router.ts` file now benefits from strong typing for its primary entry points, reducing the likelihood of future errors related to event object manipulation.

---
*PR created automatically by Jules for task [10101487952735269737](https://jules.google.com/task/10101487952735269737) started by @kurousa*