### PR TITLE
🔒 Fix Missing Input Sanitization in Google ID Token Verification

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -84,7 +84,7 @@ function verifyGoogleToken(idToken: string): boolean {
     
     try {
         // Googleの公式検証エンドポイントを叩く
-        const response = UrlFetchApp.fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${idToken}`);
+        const response = UrlFetchApp.fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${encodeURIComponent(idToken)}`);
         const tokenInfo = JSON.parse(response.getContentText());
         
         // 1. クライアントIDが自分のReactアプリのものか確認

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getOAuthService, authCallback, startAuth, resetAuth } from '../auth';
+import { getOAuthService, authCallback, startAuth, resetAuth, verifyGoogleToken, resetConfigCache } from '../auth';
 
 describe('auth', () => {
     const mockService = {
@@ -82,5 +82,28 @@ describe('auth', () => {
         resetAuth();
         expect(mockService.reset).toHaveBeenCalled();
         expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('解除しました'));
+    });
+
+    describe('verifyGoogleToken', () => {
+        beforeEach(() => {
+            resetConfigCache();
+        });
+
+        it('should correctly encode the token in the URL', () => {
+            // Mock UrlFetchApp
+            const mockResponse = {
+                getContentText: vi.fn().mockReturnValue(JSON.stringify({
+                    aud: 'fake_google_client_id',
+                    email: 'test@example.com'
+                }))
+            };
+            global.UrlFetchApp.fetch = vi.fn().mockReturnValue(mockResponse);
+
+            const tokenWithSpecialChars = 'abc/def+123=';
+            verifyGoogleToken(tokenWithSpecialChars);
+
+            const expectedEncodedToken = encodeURIComponent(tokenWithSpecialChars);
+            expect(global.UrlFetchApp.fetch).toHaveBeenCalledWith(`https://oauth2.googleapis.com/tokeninfo?id_token=${expectedEncodedToken}`);
+        });
     });
 });


### PR DESCRIPTION
🎯 What: The `idToken` parameter was directly interpolated into the Google tokeninfo verification URL without sanitization or URL encoding.
⚠️ Risk: An attacker could inject arbitrary query parameters or manipulate the URL by providing a crafted `idToken` (e.g. `someToken&otherParam=value`), causing unintended behavior or bypassing token verification.
🛡️ Solution: Used `encodeURIComponent(idToken)` to sanitize the token before inserting it into the URL, ensuring it is treated as a single parameter value.

---
*PR created automatically by Jules for task [12983132676017175474](https://jules.google.com/task/12983132676017175474) started by @kurousa*