### PR TITLE
🔒 [security] Fix WebApp execution context

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -19,7 +19,7 @@
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "webapp": {
-    "executeAs": "USER_DEPLOYING",
+    "executeAs": "USER_ACCESSING",
     "access": "MYSELF"
   }
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Changed the web application execution mode (`executeAs`) in `appsscript.json` from `USER_DEPLOYING` to `USER_ACCESSING`.

⚠️ **Risk:** The potential impact if left unfixed
When configured to execute as the deploying user, any code executing in the WebApp context runs with the permissions of the deployer, regardless of who is actually making the request. In contexts where anyone can access the app or when there is insufficient validation, this allows attackers to access data, external services, or perform actions as the developer. While Webhooks do require the script to run as the deployer (as noted in the `README.md`), keeping the default configuration file set to `USER_DEPLOYING` is a significant security risk for the baseline project configuration.

🛡️ **Solution:** How the fix addresses the vulnerability
The default configuration file was updated to use `USER_ACCESSING`, which is the secure default. This ensures the application runs under the authority of the user actually accessing it. As noted in the instructions, users needing Webhook functionality will need to manually deploy the Web App as `USER_DEPLOYING` and accessible to "Everyone", but the source code correctly defaults to a secure state.

---
*PR created automatically by Jules for task [1472344925930238929](https://jules.google.com/task/1472344925930238929) started by @kurousa*