### PR TITLE
🧪 [testing improvement] Add test for undefined VITE_GAS_DEPLOY_ID

### DIFF
--- a/dashboard/tests/dashboard_client.spec.ts
+++ b/dashboard/tests/dashboard_client.spec.ts
@@ -22,6 +22,18 @@ describe('fetchDashboardData', () => {
     await expect(fetchDashboardData('token')).rejects.toThrow('VITE_GAS_DEPLOY_ID is not defined');
   });
 
+  it('should throw error when VITE_GAS_DEPLOY_ID is completely undefined', async () => {
+    // Ensure it's strictly undefined by unstubbing all envs
+    vi.unstubAllEnvs();
+    delete process.env.VITE_GAS_DEPLOY_ID;
+
+    // We need to import the module after stubbing the environment variable
+    // because GAS_DEPLOY_ID is initialized at the top level.
+    const { fetchDashboardData } = await import('../src/api/client');
+
+    await expect(fetchDashboardData('token')).rejects.toThrow('VITE_GAS_DEPLOY_ID is not defined');
+  });
+
   it('should call fetch with correct URL when VITE_GAS_DEPLOY_ID is defined', async () => {
     const deployId = 'test-deploy-id';
     vi.stubEnv('VITE_GAS_DEPLOY_ID', deployId);

--- a/dashboard/tests/dashboard_client.spec.ts
+++ b/dashboard/tests/dashboard_client.spec.ts
@@ -23,9 +23,8 @@ describe('fetchDashboardData', () => {
   });
 
   it('should throw error when VITE_GAS_DEPLOY_ID is completely undefined', async () => {
-    // Ensure it's strictly undefined by unstubbing all envs
-    vi.unstubAllEnvs();
-    delete process.env.VITE_GAS_DEPLOY_ID;
+    // Ensure it's strictly undefined
+    vi.stubEnv('VITE_GAS_DEPLOY_ID', undefined as any);
 
     // We need to import the module after stubbing the environment variable
     // because GAS_DEPLOY_ID is initialized at the top level.

--- a/dashboard/tests/dashboard_client.spec.ts
+++ b/dashboard/tests/dashboard_client.spec.ts
@@ -23,8 +23,9 @@ describe('fetchDashboardData', () => {
   });
 
   it('should throw error when VITE_GAS_DEPLOY_ID is completely undefined', async () => {
-    // Ensure it's strictly undefined
-    vi.stubEnv('VITE_GAS_DEPLOY_ID', undefined as any);
+    // Ensure it's strictly undefined by unstubbing all envs
+    vi.unstubAllEnvs();
+    delete process.env.VITE_GAS_DEPLOY_ID;
 
     // We need to import the module after stubbing the environment variable
     // because GAS_DEPLOY_ID is initialized at the top level.
@@ -49,7 +50,7 @@ describe('fetchDashboardData', () => {
 
     vi.mocked(fetch).mockResolvedValue({
       json: () => Promise.resolve(mockResponse)
-    } as Response);
+    } as unknown as Response);
 
     const { fetchDashboardData } = await import('../src/api/client');
     const result = await fetchDashboardData('fake-token');
@@ -76,7 +77,7 @@ describe('fetchDashboardData', () => {
 
     vi.mocked(fetch).mockResolvedValue({
       json: () => Promise.resolve(mockErrorResponse)
-    } as Response);
+    } as unknown as Response);
 
     const { fetchDashboardData } = await import('../src/api/client');
 
@@ -92,7 +93,7 @@ describe('fetchDashboardData', () => {
 
     vi.mocked(fetch).mockResolvedValue({
       json: () => Promise.resolve(mockErrorResponse)
-    } as Response);
+    } as unknown as Response);
 
     const { fetchDashboardData } = await import('../src/api/client');
 


### PR DESCRIPTION
🎯 **What:** The `getGasUrl` function in `dashboard/src/api/client.ts` throws an error if `VITE_GAS_DEPLOY_ID` is not defined. We had a test verifying the throw when the value is an empty string, but missed a test for the completely undefined scenario.

📊 **Coverage:** The test suite now explicitly unstubs all environment variables using `vi.unstubAllEnvs()` and deletes `process.env.VITE_GAS_DEPLOY_ID` before importing `client.ts`. This verifies the true `undefined` edge case where the environment variable is completely absent at module load time.

✨ **Result:** Improved test coverage and correctness by ensuring the error path is triggered under all falsy/missing conditions.

---
*PR created automatically by Jules for task [9135027940788731336](https://jules.google.com/task/9135027940788731336) started by @kurousa*