### PR TITLE
🧪 Add error path test for saveMapToDrive in maps.ts

### DIFF
--- a/tests/maps.spec.ts
+++ b/tests/maps.spec.ts
@@ -69,6 +69,38 @@ describe('maps.ts', () => {
             expect(mockFolder.getFilesByName).toHaveBeenCalledWith('strava_map_12345.png');
         });
 
+        it('should return null and log error if map generation fails', () => {
+            const mockFiles = {
+                hasNext: vi.fn().mockReturnValue(false)
+            };
+            const mockFolder = {
+                getFilesByName: vi.fn().mockReturnValue(mockFiles),
+            };
+
+            const mockFolders = {
+                hasNext: vi.fn().mockReturnValue(true),
+                next: vi.fn().mockReturnValue(mockFolder)
+            };
+            (global as any).DriveApp.getFoldersByName.mockReturnValue(mockFolders);
+
+            // Mock getBlob to throw an error
+            const errorMsg = 'Failed to generate map blob';
+            const mockMap = {
+                setSize: vi.fn().mockReturnThis(),
+                setLanguage: vi.fn().mockReturnThis(),
+                addPath: vi.fn().mockReturnThis(),
+                getBlob: vi.fn().mockImplementation(() => {
+                    throw new Error(errorMsg);
+                })
+            };
+            vi.spyOn((global as any).Maps, 'newStaticMap').mockReturnValueOnce(mockMap);
+
+            const result = saveMapToDrive(mockActivity as any);
+            expect(result).toBeNull();
+            expect(Logger.log).toHaveBeenCalledWith(expect.stringContaining('マップの保存に失敗しました'));
+            expect(Logger.log).toHaveBeenCalledWith(expect.stringContaining(errorMsg));
+        });
+
         it('should create and return new file if it does not exist', () => {
             const mockFile = {
                 setName: vi.fn().mockReturnThis(),


### PR DESCRIPTION
🎯 **What:** The testing gap in `maps.ts` where map generation errors were not covered by tests has been addressed.
📊 **Coverage:** Added a scenario testing the error path of `saveMapToDrive` to ensure it returns `null` and logs the error correctly when `map.getBlob()` fails.
✨ **Result:** Improved test coverage and reliability for map generation functionality.

---
*PR created automatically by Jules for task [3806060608776272120](https://jules.google.com/task/3806060608776272120) started by @kurousa*