### PR TITLE
🔒 Fix Insecure Execution Mode in Appsscript Configuration

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -19,7 +19,7 @@
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "webapp": {
-    "executeAs": "USER_DEPLOYING",
+    "executeAs": "USER_ACCESSING",
     "access": "MYSELF"
   }
 }


### PR DESCRIPTION
🎯 **What:** Changed the `executeAs` setting in `appsscript.json` from `USER_DEPLOYING` to `USER_ACCESSING`.
⚠️ **Risk:** Running a web app as `USER_DEPLOYING` means that the application runs with the permissions of the developer who deployed it. This can lead to unauthorized access to the developer's Google services (e.g., Calendar, Drive, Spreadsheets) by anyone who accesses the web app. This is an insecure execution mode and a potential privilege escalation vector.
🛡️ **Solution:** Altered the execution scope to `USER_ACCESSING`. This ensures that anyone executing the web app must authorize the application with their own account, and the code runs with their permissions, adhering to security best practices. As noted in the README and project documentation, users can still manually switch back to `USER_DEPLOYING` if they require webhook functionality, but the safe and secure setting is now the default in code.

---
*PR created automatically by Jules for task [10121792413322068274](https://jules.google.com/task/10121792413322068274) started by @kurousa*