### PR TITLE
Replace 'xxx' placeholder in main.ts comment

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -202,7 +202,7 @@ function processActivityToCalendar(
         if (files.hasNext()) {
             const file = files.next();
             // Google Calendar API (v3) を使って添付ファイルを追加
-            // 標準のIDは "xxxx@google.com" 形式なので、ID部分のみ抽出
+            // 標準のIDは "event_id@google.com" 形式なので、ID部分のみ抽出
             const eventId = event.getId().split('@')[0];
             try {
                 // global の Calendar オブジェクト (Advanced Service) を使用


### PR DESCRIPTION
This change replaces a placeholder string in a comment that contained 'xxxx', which was flagged as an 'XXX' marker. The new placeholder 'event_id@google.com' is more descriptive and avoids the marker detection. No functional code was changed.

---
*PR created automatically by Jules for task [12732913852483447129](https://jules.google.com/task/12732913852483447129) started by @kurousa*