### PR TITLE
🧹 [Code Health] Reduce nesting by extracting ID gathering logic

### DIFF
--- a/sheets.ts
+++ b/sheets.ts
@@ -31,13 +31,8 @@ function backupToSpreadsheet(activities: StravaActivity[]): void {
             sheet.getRange(1, 1, 1, headers.length).setFontWeight('bold');
         }
         
-        const existingIds = new Set<string>();
+        const existingIds = getExistingSheetActivityIds(sheet);
         const lastRow = sheet.getLastRow();
-        if (lastRow > 1) {
-            sheet.getRange(2, 1, lastRow - 1, 1).getValues().flat().forEach(id => {
-                if (id) existingIds.add(String(id));
-            });
-        }
 
         const rows = activities.map(activity => {
             if (existingIds.has(String(activity.id))) {
@@ -90,9 +85,24 @@ function backupToSpreadsheet(activities: StravaActivity[]): void {
     }
 }
 
+/**
+ * シートから既存のアクティビティIDのセットを取得する
+ */
+function getExistingSheetActivityIds(sheet: GoogleAppsScript.Spreadsheet.Sheet): Set<string> {
+    const existingIds = new Set<string>();
+    const lastRow = sheet.getLastRow();
+    if (lastRow > 1) {
+        sheet.getRange(2, 1, lastRow - 1, 1).getValues().flat().forEach(id => {
+            if (id) existingIds.add(String(id));
+        });
+    }
+    return existingIds;
+}
+
 // Node.js環境（テスト時）のみエクスポートする
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
-        backupToSpreadsheet
+        backupToSpreadsheet,
+        getExistingSheetActivityIds
     };
 }


### PR DESCRIPTION
🎯 What: Extracted deeply nested logic from `backupToSpreadsheet` into `getExistingSheetActivityIds` in `sheets.ts`.
💡 Why: Reduces nesting and complexity in the main `backupToSpreadsheet` method, enhancing readability and maintainability. It follows the single responsibility principle better.
✅ Verification: Confirmed `pnpm run test` and `pnpm run typecheck` pass without errors.
✨ Result: The code is cleaner, easier to follow, and the logic is successfully encapsulated into a new method.

---
*PR created automatically by Jules for task [9757554978732813403](https://jules.google.com/task/9757554978732813403) started by @kurousa*