### PR TITLE
🧹 [code health improvement] Refactor getExistingSheetActivityIds for early return

### DIFF
--- a/sheets.ts
+++ b/sheets.ts
@@ -103,11 +103,12 @@ function backupToSpreadsheet(activities: StravaActivity[]): void {
 function getExistingSheetActivityIds(sheet: GoogleAppsScript.Spreadsheet.Sheet): Set<string> {
     const existingIds = new Set<string>();
     const lastRow = sheet.getLastRow();
-    if (lastRow > 1) {
-        sheet.getRange(2, 1, lastRow - 1, 1).getValues().flat().forEach(id => {
-            if (id) existingIds.add(String(id));
-        });
-    }
+    if (lastRow <= 1) return existingIds;
+
+    sheet.getRange(2, 1, lastRow - 1, 1).getValues().flat().forEach(id => {
+        if (id) existingIds.add(String(id));
+    });
+
     return existingIds;
 }
 


### PR DESCRIPTION
🎯 **What:** Refactored `getExistingSheetActivityIds` in `sheets.ts` to use an early return when `lastRow <= 1`.
💡 **Why:** This reduces the nesting level of the logic block inside `getExistingSheetActivityIds`, making the code cleaner and easier to read.
✅ **Verification:** Verified by successfully running the full `vitest` test suite via `pnpm test`. All 180 tests passed, confirming no regressions.
✨ **Result:** Improved codebase maintainability by reducing nested conditionals without altering expected behavior.

---
*PR created automatically by Jules for task [11761688381099822364](https://jules.google.com/task/11761688381099822364) started by @kurousa*