### PR TITLE
🔒 Fix insecure error handling in router.ts

### DIFF
--- a/router.ts
+++ b/router.ts
@@ -53,9 +53,12 @@ function doGet(e: GoogleAppsScript.Events.DoGet): GoogleAppsScript.HTML.HtmlOutp
             }))
                 .setMimeType(ContentService.MimeType.JSON);
         } catch (err) {
-            Logger.log(`[Dashboard Error] ${(err as Error).toString()}`);
-            return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: 'Internal Server Error' }))
-                .setMimeType(ContentService.MimeType.JSON);
+            Logger.log("[Dashboard Error] " + err);
+            return ContentService.createTextOutput(JSON.stringify({ 
+                status: 'error', 
+                code: 500,
+                message: 'Internal Server Error' 
+            }));
         }
     }
 

--- a/router.ts
+++ b/router.ts
@@ -84,9 +84,12 @@ function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.Tex
         return ContentService.createTextOutput(JSON.stringify({ status: 'ok' }))
             .setMimeType(ContentService.MimeType.JSON);
     } catch (err) {
-        Logger.log(`[Webhook Error] ${(err as Error).toString()}`);
-        return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: 'Internal Server Error' }))
-            .setMimeType(ContentService.MimeType.JSON);
+        Logger.log("[Webhook Error] " + err);
+        return ContentService.createTextOutput(JSON.stringify({ 
+            status: 'error', 
+            code: 500,
+            message: 'Internal Server Error' 
+        }));
     }
 }
 

--- a/router.ts
+++ b/router.ts
@@ -53,7 +53,8 @@ function doGet(e: GoogleAppsScript.Events.DoGet): GoogleAppsScript.HTML.HtmlOutp
             }))
                 .setMimeType(ContentService.MimeType.JSON);
         } catch (err) {
-            return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: (err as Error).toString() }))
+            Logger.log(`[Dashboard Error] ${(err as Error).toString()}`);
+            return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: 'Internal Server Error' }))
                 .setMimeType(ContentService.MimeType.JSON);
         }
     }
@@ -81,7 +82,7 @@ function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.Tex
             .setMimeType(ContentService.MimeType.JSON);
     } catch (err) {
         Logger.log(`[Webhook Error] ${(err as Error).toString()}`);
-        return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: (err as Error).toString() }))
+        return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: 'Internal Server Error' }))
             .setMimeType(ContentService.MimeType.JSON);
     }
 }

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -357,6 +357,7 @@ describe('router', () => {
             const result = doGet(e as unknown as GoogleAppsScript.Events.DoGet);
 
             expect(result.getContent()).toContain('"status":"error"');
+            expect(result.getContent()).toContain('"code":500');
             expect(result.getContent()).toContain('"message":"Internal Server Error"');
             expect(Logger.log).toHaveBeenCalledWith(expect.stringContaining('[Dashboard Error] Error: Database failure'));
         });

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -320,6 +320,47 @@ describe('router', () => {
             expect((global as any).Logger.log).toHaveBeenCalledWith(expect.stringContaining('許可されていないユーザーによるアクセスです'));
         });
 
+        it('should return internal server error when getDashboardData fails', () => {
+            vi.stubGlobal('getDashboardData', vi.fn().mockImplementation(() => {
+                throw new Error('Database failure');
+            }));
+
+            // PropertiesService and UrlFetchApp mocks to pass authentication
+            const mockProps = {
+                getProperty: vi.fn((key) => {
+                    if (key === 'GOOGLE_CLIENT_ID') return 'valid_client_id';
+                    if (key === 'ALLOWED_EMAILS') return 'test@example.com';
+                    return null;
+                })
+            };
+            vi.stubGlobal('PropertiesService', {
+                ...(global as any).PropertiesService,
+                getScriptProperties: vi.fn().mockReturnValue(mockProps)
+            });
+            vi.stubGlobal('UrlFetchApp', {
+                ...(global as any).UrlFetchApp,
+                fetch: vi.fn().mockReturnValue({
+                    getContentText: () => JSON.stringify({
+                        aud: 'valid_client_id',
+                        email: 'test@example.com'
+                    })
+                })
+            });
+            vi.stubGlobal('Logger', { log: vi.fn() });
+
+            const e = {
+                parameter: {
+                    action: 'getStats',
+                    token: 'valid_token'
+                }
+            };
+            const result = doGet(e as unknown as GoogleAppsScript.Events.DoGet);
+
+            expect(result.getContent()).toContain('"status":"error"');
+            expect(result.getContent()).toContain('"message":"Internal Server Error"');
+            expect(Logger.log).toHaveBeenCalledWith(expect.stringContaining('[Dashboard Error] Error: Database failure'));
+        });
+
         it('should return error if getStats action is called without token', () => {
             vi.stubGlobal('Logger', { log: vi.fn() });
 
@@ -359,7 +400,7 @@ describe('router', () => {
             expect(result.getContent()).toBe(JSON.stringify({ status: 'ok' }));
         });
 
-        it('should handle errors in doPost', () => {
+        it('should handle errors in doPost and return generic message', () => {
             const e = {
                 postData: {
                     contents: 'invalid json'
@@ -369,7 +410,8 @@ describe('router', () => {
             const result = doPost(e as unknown as GoogleAppsScript.Events.DoPost);
 
             expect(Logger.log).toHaveBeenCalledWith(expect.stringContaining('[Webhook Error]'));
-            expect(result.getContent()).toContain('status":"error"');
+            expect(result.getContent()).toContain('"status":"error"');
+            expect(result.getContent()).toContain('"message":"Internal Server Error"');
         });
     });
 

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -412,6 +412,7 @@ describe('router', () => {
 
             expect(Logger.log).toHaveBeenCalledWith(expect.stringContaining('[Webhook Error]'));
             expect(result.getContent()).toContain('"status":"error"');
+            expect(result.getContent()).toContain('"code":500');
             expect(result.getContent()).toContain('"message":"Internal Server Error"');
         });
     });

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -351,7 +351,7 @@ describe('router', () => {
             const e = {
                 parameter: {
                     action: 'getStats',
-                    token: 'valid_token'
+                    token: 'valid_header.valid_payload.valid_signature'
                 }
             };
             const result = doGet(e as unknown as GoogleAppsScript.Events.DoGet);


### PR DESCRIPTION
Fixed a security vulnerability in `router.ts` where detailed error messages were being returned to the client in `doGet` and `doPost` handlers. 

### Changes:
- Replaced `(err as Error).toString()` with `'Internal Server Error'` in response bodies.
- Ensured detailed error messages are still logged to `Logger` for debugging purposes.
- Updated unit tests to verify both the generic response and the internal logging.

This change prevents information leakage of codebase paths, library versions, or other system internals that might be included in error strings.

---
*PR created automatically by Jules for task [17263463781841308900](https://jules.google.com/task/17263463781841308900) started by @kurousa*