### PR TITLE
Update Strava API base URL

### DIFF
--- a/const.ts
+++ b/const.ts
@@ -42,7 +42,7 @@ var Config = {
     PROP_WEATHER_API_KEY: 'WEATHER_API_KEY', // GASのプロパティに設定するキー名
 
     // API エンドポイント
-    STRAVA_API_BASE: 'https://www.strava.com/api/v3',
+    STRAVA_API_BASE: 'https://www.api-v3.strava.com',
     WEATHER_API_BASE: 'https://api.weatherapi.com/v1',
     GEMINI_API_BASE: `https://generativelanguage.googleapis.com/v1beta/models/gemini-${_GEMINI_VERSION}-${_GEMINI_MODEL}:generateContent`,
 

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -37,7 +37,7 @@ describe('api', () => {
 
         expect(result).toEqual(activities);
         expect(global.UrlFetchApp.fetch).toHaveBeenCalledWith(
-            expect.stringMatching(/https:\/\/www\.strava\.com\/api\/v3\/athlete\/activities/),
+            expect.stringMatching(/https:\/\/www\.api-v3\.strava\.com\/athlete\/activities/),
             expect.objectContaining({
                 headers: {
                     Authorization: 'Bearer fake_token'
@@ -142,7 +142,7 @@ describe('api', () => {
 
             expect(result).toEqual(athlete);
             expect(global.UrlFetchApp.fetch).toHaveBeenCalledWith(
-                'https://www.strava.com/api/v3/athlete',
+                'https://www.api-v3.strava.com/athlete',
                 expect.objectContaining({
                     headers: {
                         Authorization: 'Bearer fake_token'

--- a/tests/const.spec.ts
+++ b/tests/const.spec.ts
@@ -64,7 +64,7 @@ describe('const.ts', () => {
             expect(Config.PROP_LAST_ERROR_NOTIFIED_AT).toBe('LAST_ERROR_NOTIFIED_AT');
             expect(Config.PROP_WEATHER_API_KEY).toBe('WEATHER_API_KEY');
 
-            expect(Config.STRAVA_API_BASE).toBe('https://www.strava.com/api/v3');
+            expect(Config.STRAVA_API_BASE).toBe('https://www.api-v3.strava.com');
             expect(Config.WEATHER_API_BASE).toBe('https://api.weatherapi.com/v1');
             expect(Config.GEMINI_API_BASE).toBe(`https://generativelanguage.googleapis.com/v1beta/models/gemini-${_GEMINI_VERSION}-${_GEMINI_MODEL}:generateContent`);
 
@@ -96,7 +96,7 @@ describe('const.ts', () => {
     describe('Global expansion', () => {
         it('should expand Config properties to global', () => {
             // These are defined in Config and should be available globally
-            expect((global as any).STRAVA_API_BASE).toBe('https://www.strava.com/api/v3');
+            expect((global as any).STRAVA_API_BASE).toBe('https://www.api-v3.strava.com');
             expect((global as any).DISTANCE_ACTIVITIES).toContain('Run');
         });
     });


### PR DESCRIPTION
The Strava API base URL is being migrated to a new endpoint. This PR updates the `STRAVA_API_BASE` constant in `const.ts` from `https://www.strava.com/api/v3` to `https://www.api-v3.strava.com`. Corresponding unit tests in `tests/const.spec.ts` and `tests/api.spec.ts` have also been updated to ensure the application correctly targets the new URL. All tests passed successfully.

Fixes #183

---
*PR created automatically by Jules for task [2540279950686766240](https://jules.google.com/task/2540279950686766240) started by @kurousa*