### PR TITLE
Migrate Strava deauthorization to oauth/revoke

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -76,14 +76,11 @@ function resetAuth(): void {
     if (service.hasAccess()) {
         try {
             const accessToken = service.getAccessToken();
-            const props = PropertiesService.getScriptProperties();
-            const clientId = props.getProperty(Config.PROP_STRAVA_CLIENT_ID);
-            const clientSecret = props.getProperty(Config.PROP_STRAVA_CLIENT_SECRET);
 
-            if (clientId && clientSecret) {
+            if (cachedStravaClientId && cachedStravaClientSecret) {
                 // Strava API v3 oauth/revoke エンドポイントを叩く
                 // Basic認証が必要 (client_id:client_secret を Base64エンコード)
-                const authHeader = 'Basic ' + Utilities.base64Encode(clientId + ':' + clientSecret);
+                const authHeader = 'Basic ' + Utilities.base64Encode(cachedStravaClientId + ':' + cachedStravaClientSecret);
 
                 UrlFetchApp.fetch(Config.STRAVA_REVOKE_URL, {
                     method: 'post',

--- a/auth.ts
+++ b/auth.ts
@@ -31,8 +31,8 @@ function getOAuthService(): any {
         throw new Error(`${Config.PROP_STRAVA_CLIENT_ID} または ${Config.PROP_STRAVA_CLIENT_SECRET} がスクリプトプロパティに設定されていません。`);
     }
     return OAuth2.createService('Strava')
-        .setAuthorizationBaseUrl('https://www.strava.com/oauth/authorize')
-        .setTokenUrl('https://www.strava.com/oauth/token')
+        .setAuthorizationBaseUrl(Config.STRAVA_AUTH_URL)
+        .setTokenUrl(Config.STRAVA_TOKEN_URL)
         .setClientId(CLIENT_ID)
         .setClientSecret(CLIENT_SECRET)
         .setCallbackFunction('authCallback')
@@ -72,7 +72,38 @@ function startAuth(): void {
  * 連携を解除したい時用の関数（普段は使いません）
  */
 function resetAuth(): void {
-    getOAuthService().reset();
+    const service = getOAuthService();
+    if (service.hasAccess()) {
+        try {
+            const accessToken = service.getAccessToken();
+            const props = PropertiesService.getScriptProperties();
+            const clientId = props.getProperty(Config.PROP_STRAVA_CLIENT_ID);
+            const clientSecret = props.getProperty(Config.PROP_STRAVA_CLIENT_SECRET);
+
+            if (clientId && clientSecret) {
+                // Strava API v3 oauth/revoke エンドポイントを叩く
+                // Basic認証が必要 (client_id:client_secret を Base64エンコード)
+                const authHeader = 'Basic ' + Utilities.base64Encode(clientId + ':' + clientSecret);
+
+                UrlFetchApp.fetch(Config.STRAVA_REVOKE_URL, {
+                    method: 'post',
+                    headers: {
+                        'Authorization': authHeader,
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    payload: {
+                        'token': accessToken
+                    },
+                    muteHttpExceptions: true
+                });
+                Logger.log('Stravaサーバー側の連携解除リクエストを送信しました。');
+            }
+        } catch (e) {
+            Logger.log('Strava連携解除リクエスト中にエラーが発生しましたが、ローカルの認証情報はリセットします: ' + (e as Error).toString());
+        }
+    }
+
+    service.reset();
     Logger.log('連携を解除しました。');
 }
 

--- a/const.ts
+++ b/const.ts
@@ -43,6 +43,9 @@ var Config = {
 
     // API エンドポイント
     STRAVA_API_BASE: 'https://www.strava.com/api/v3',
+    STRAVA_AUTH_URL: 'https://www.strava.com/oauth/authorize',
+    STRAVA_TOKEN_URL: 'https://www.strava.com/oauth/token',
+    STRAVA_REVOKE_URL: 'https://www.strava.com/oauth/revoke',
     WEATHER_API_BASE: 'https://api.weatherapi.com/v1',
     GEMINI_API_BASE: `https://generativelanguage.googleapis.com/v1beta/models/gemini-${_GEMINI_VERSION}-${_GEMINI_MODEL}:generateContent`,
 

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -12,6 +12,7 @@ describe('auth', () => {
         setScope: vi.fn().mockReturnThis(),
         handleCallback: vi.fn(),
         hasAccess: vi.fn(),
+        getAccessToken: vi.fn(),
         getAuthorizationUrl: vi.fn(),
         reset: vi.fn()
     };
@@ -80,9 +81,52 @@ describe('auth', () => {
         expect(global.Logger.log).toHaveBeenCalledWith('https://example.com/auth');
     });
 
-    it('should reset auth', () => {
+    it('should reset auth and call revoke endpoint if has access', () => {
+        mockService.hasAccess.mockReturnValue(true);
+        mockService.getAccessToken.mockReturnValue('fake_access_token');
+        (global as any).Utilities.base64Encode = vi.fn().mockReturnValue('encoded_creds');
+        (global as any).UrlFetchApp.fetch = vi.fn();
+
         resetAuth();
+
         expect(mockService.reset).toHaveBeenCalled();
+        expect(global.UrlFetchApp.fetch).toHaveBeenCalledWith(
+            'https://www.strava.com/oauth/revoke',
+            expect.objectContaining({
+                method: 'post',
+                headers: expect.objectContaining({
+                    'Authorization': 'Basic encoded_creds'
+                }),
+                payload: {
+                    'token': 'fake_access_token'
+                }
+            })
+        );
+        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('解除しました'));
+    });
+
+    it('should reset auth even if revoke endpoint fails', () => {
+        mockService.hasAccess.mockReturnValue(true);
+        mockService.getAccessToken.mockReturnValue('fake_access_token');
+        (global as any).UrlFetchApp.fetch = vi.fn().mockImplementation(() => {
+            throw new Error('API Error');
+        });
+
+        resetAuth();
+
+        expect(mockService.reset).toHaveBeenCalled();
+        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('エラーが発生しましたが'));
+        expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('解除しました'));
+    });
+
+    it('should just reset auth if no access', () => {
+        mockService.hasAccess.mockReturnValue(false);
+        (global as any).UrlFetchApp.fetch = vi.fn();
+
+        resetAuth();
+
+        expect(mockService.reset).toHaveBeenCalled();
+        expect(global.UrlFetchApp.fetch).not.toHaveBeenCalled();
         expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('解除しました'));
     });
 

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -84,8 +84,8 @@ describe('auth', () => {
     it('should reset auth and call revoke endpoint if has access', () => {
         mockService.hasAccess.mockReturnValue(true);
         mockService.getAccessToken.mockReturnValue('fake_access_token');
-        (global as any).Utilities.base64Encode = vi.fn().mockReturnValue('encoded_creds');
-        (global as any).UrlFetchApp.fetch = vi.fn();
+        vi.stubGlobal('Utilities', { base64Encode: vi.fn().mockReturnValue('encoded_creds') });
+        vi.stubGlobal('UrlFetchApp', { fetch: vi.fn() });
 
         resetAuth();
 
@@ -108,8 +108,10 @@ describe('auth', () => {
     it('should reset auth even if revoke endpoint fails', () => {
         mockService.hasAccess.mockReturnValue(true);
         mockService.getAccessToken.mockReturnValue('fake_access_token');
-        (global as any).UrlFetchApp.fetch = vi.fn().mockImplementation(() => {
-            throw new Error('API Error');
+        vi.stubGlobal('UrlFetchApp', {
+            fetch: vi.fn().mockImplementation(() => {
+                throw new Error('API Error');
+            })
         });
 
         resetAuth();
@@ -121,7 +123,7 @@ describe('auth', () => {
 
     it('should just reset auth if no access', () => {
         mockService.hasAccess.mockReturnValue(false);
-        (global as any).UrlFetchApp.fetch = vi.fn();
+        vi.stubGlobal('UrlFetchApp', { fetch: vi.fn() });
 
         resetAuth();
 


### PR DESCRIPTION
This change migrates the Strava authentication deauthorization logic from the deprecated `oauth/deauthorize` endpoint to the new `oauth/revoke` endpoint. 

Since the Google Apps Script OAuth2 library's `.reset()` method only clears local credentials, a manual call to Strava's revocation API was implemented in `resetAuth()`. The implementation follows Strava's requirements for the new endpoint, including the use of Basic Authentication and passing the token to be revoked. 

Error handling ensures that local credentials are always cleared even if the remote revocation fails. Tests have been updated to verify the new behavior.

Fixes #184

---
*PR created automatically by Jules for task [402680040138989640](https://jules.google.com/task/402680040138989640) started by @kurousa*